### PR TITLE
match() -> test()

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -103,7 +103,7 @@ exports.request = function (method, url, options, callback, _trace) {
             return finish(Boom.badGateway('Received redirection without location', _trace));
         }
 
-        if (!location.match(/^https?:/i)) {
+        if (!/^https?:/i.test(location)) {
             location = Url.resolve(uri.href, location);
         }
 


### PR DESCRIPTION
Replace `match()` with `test()` as result is used as a Boolean.
