### PR TITLE
Hoek version bump to 2.x.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "node": ">=0.10.22"
   },
   "dependencies": {
-    "hoek": "1.x.x",
+    "hoek": "2.x.x",
     "boom": "2.x.x"
   },
   "devDependencies": {


### PR DESCRIPTION
Version bump for Hoek dependency.  All tests still pass with 100% coverage (lab upgrade still pending in #9).
