### PR TITLE
Prevent starvation due to timeout requests

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -58,7 +58,11 @@ exports.request = function (method, url, options, callback, _trace) {
             req.abort();
         }
 
-        req.removeAllListeners();
+        // Must manually cleanup events. Remove all causes system level events to be removed,
+        // which can cause socket starvation if attempting to utilize a connection that was
+        // aborted prior to having a socket associated with it.
+        req.removeListener('response', response);
+        req.removeAllListeners('error');
         req.on('error', Hoek.ignore);
         clearTimeout(timeoutId);
 
@@ -75,7 +79,8 @@ exports.request = function (method, url, options, callback, _trace) {
         return finish(Boom.badGateway('Client request error', err));
     });
 
-    req.once('response', function (res) {
+
+    var response = function (res) {
 
         // Pass-through response
 
@@ -111,7 +116,8 @@ exports.request = function (method, url, options, callback, _trace) {
         };
 
         return exports.request(redirectMethod, location, redirectOptions, finish, _trace);
-    });
+    }
+    req.once('response', response);
 
     if (options.timeout) {
         timeoutId = setTimeout(function () {


### PR DESCRIPTION
When requests timeout while they are still in the agent's request pool, they
depend on a variety of events to occur to cleanup the pool. When this does not
happen the sockets are left in a opened but unused state, counting against the
connection pool limit. When enough of these cases the limit will be exhausted
and no further requests can be processed.
