### PR TITLE
allow for unicode characters in string payloads, closes #20

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -33,7 +33,7 @@ exports.request = function (method, url, options, callback, _trace) {
         (typeof options.payload === 'string' || Buffer.isBuffer(options.payload))) {
 
         uri.headers = Hoek.clone(uri.headers) || {};
-        uri.headers['Content-Length'] = options.payload.length;
+        uri.headers['Content-Length'] = Buffer.isBuffer(options.payload) ? options.payload.length : Buffer.byteLength(options.payload);
     }
 
     if (options.rejectUnauthorized !== undefined && uri.protocol === 'https:') {

--- a/test/index.js
+++ b/test/index.js
@@ -80,6 +80,32 @@ describe('Nipple', function () {
             });
         });
 
+        it('requests a POST resource with unicode characters in payload', function (done) {
+
+            var server = Http.createServer(function (req, res) {
+
+                expect(req.headers['content-length']).to.equal('14');
+                res.writeHead(200, { 'Content-Type': 'text/plain' });
+                req.pipe(res);
+            });
+
+            server.listen(0, function () {
+
+                var unicodePayload = JSON.stringify({ field: 'ć' });
+                Nipple.request('post', 'http://localhost:' + server.address().port, { payload: unicodePayload }, function (err, res) {
+
+                    expect(err).to.not.exist;
+                    Nipple.read(res, function (err, body) {
+
+                        expect(err).to.not.exist;
+                        expect(body.toString()).to.equal(unicodePayload);
+                        server.close();
+                        done();
+                    });
+                });
+            });
+        });
+
         it('requests a POST resource with headers', function (done) {
 
             var server = Http.createServer(function (req, res) {


### PR DESCRIPTION
If `options.payload` is a string, we should use `Buffer.byteLength(options.payload)` instead of `options.payload.length`
