### PR TITLE
Dont try to parse JSON if the statusCode is 204 (No Content)

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -231,6 +231,10 @@ exports.read = function (res, options, callback) {
             return callback(null, buffer);
         }
 
+        if (buffer.length === 0) {
+            return callback(null, null);
+        }
+
         try {
             var json = JSON.parse(buffer.toString());
         }

--- a/test/index.js
+++ b/test/index.js
@@ -1374,6 +1374,32 @@ describe('json', function () {
             });
         });
     });
+
+    it('should not be parsed on empty buffer', function (done) {
+
+        var server = Http.createServer(function (req, res) {
+
+            res.writeHead(204, { 'Content-Type': 'application/json' });
+            res.end();
+        });
+
+        server.listen(0, function () {
+
+            var port = server.address().port;
+            var options = {
+                json: true
+            };
+
+            Wreck.get('http://localhost:' + port, options, function (err, res, payload) {
+
+                expect(err).to.not.exist();
+                expect(res.statusCode).to.equal(204);
+                expect(payload).to.equal(null);
+                server.close();
+                done();
+            });
+        });
+    });
 });
 
 describe('toReadableStream()', function () {
@@ -1418,4 +1444,3 @@ describe('toReadableStream()', function () {
         done();
     });
 });
-


### PR DESCRIPTION
I dont think that wreck should try to parse json when the status code is 204 no content.
We keep getting '''Unexpected end of line''' and other errors. 

I have created a test and updated the code not to parse JSON if the statusCode is 204.

If there is any problem with it, just let me know :)
