### PR TITLE
Added 'smart' and 'force' modes to json option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,8 +85,9 @@ Returns an instance of the node.js [ClientRequest](http://nodejs.org/api/http.ht
 - `options` - `null` or a configuration object with the following optional keys:
     - `timeout` - The number of milliseconds to wait while reading data before
     aborting handling of the response. Defaults to unlimited.
-    - `json` - A flag indicating whether the payload should be parsed as JSON
-    if the response indicates a JSON content-type.
+    - `json` - A value indicating how to try to parse the payload as JSON. Defaults to `undefined` meaning no parse logic.
+        - `true`, 'smart' - only try `JSON.parse` if the response indicates a JSON content-type.
+        - `force` - try `JSON.parse` regardless of the content-type header.
     - `maxBytes` - The maximum allowed response payload size. Defaults to unlimited.
 - `callback` - The callback function using the signature `function (err, payload)` where:
     - `err` - Any error that may have occurred while reading the response.

--- a/lib/index.js
+++ b/lib/index.js
@@ -223,18 +223,16 @@ exports.read = function (res, options, callback) {
         // Parse JSON
 
         var result;
-        var mode = (options.json === true || options.json.toLowerCase() === 'smart') ? 'smart' : 'force';
-
         if (buffer.length === 0) {
             return callback(null, null);
         }
 
-        if (mode === 'force') {
+        if (options.json === 'force') {
             result = internals.tryParseBuffer(buffer);
             return callback(result.err, result.json);
         }
 
-        // mode is "smart"
+        // mode is "smart" or true
 
         var contentType = (res.headers && res.headers['content-type']) || '';
         var mime = contentType.split(';')[0].trim().toLowerCase();

--- a/lib/index.js
+++ b/lib/index.js
@@ -216,13 +216,25 @@ exports.read = function (res, options, callback) {
         res.removeListener('close', onResClose);
         res.on('error', Hoek.ignore);
 
-        if (err ||
-            !options.json) {
-
+        if (err || !options.json) {
             return callback(err, buffer);
         }
 
         // Parse JSON
+
+        var result;
+        var mode = (options.json === true || options.json.toLowerCase() === 'smart') ? 'smart' : 'force';
+
+        if (buffer.length === 0) {
+            return callback(null, null);
+        }
+
+        if (mode === 'force') {
+            result = internals.tryParseBuffer(buffer);
+            return callback(result.err, result.json);
+        }
+
+        // mode is "smart"
 
         var contentType = (res.headers && res.headers['content-type']) || '';
         var mime = contentType.split(';')[0].trim().toLowerCase();
@@ -231,18 +243,8 @@ exports.read = function (res, options, callback) {
             return callback(null, buffer);
         }
 
-        if (buffer.length === 0) {
-            return callback(null, null);
-        }
-
-        try {
-            var json = JSON.parse(buffer.toString());
-        }
-        catch (err) {
-            return callback(err, null);
-        }
-
-        return callback(null, json);
+        result = internals.tryParseBuffer(buffer);
+        return callback(result.err, result.json);
     };
 
     finish = Hoek.once(finish);
@@ -384,4 +386,21 @@ internals.shortcut = function (method, uri, options, callback) {
             return callback(err, res, payload);
         });
     });
+};
+
+
+internals.tryParseBuffer = function (buffer) {
+
+    var result = {
+        json: null,
+        err: null
+    };
+    try {
+        var json = JSON.parse(buffer.toString());
+        result.json = json;
+    }
+    catch (err) {
+        result.err = err;
+    }
+    return result;
 };

--- a/test/index.js
+++ b/test/index.js
@@ -1387,7 +1387,7 @@ describe('json', function () {
 
             var port = server.address().port;
             var options = {
-                json: true
+                json: 'SMART'
             };
 
             Wreck.get('http://localhost:' + port, options, function (err, res, payload) {
@@ -1395,6 +1395,59 @@ describe('json', function () {
                 expect(err).to.not.exist();
                 expect(res.statusCode).to.equal(204);
                 expect(payload).to.equal(null);
+                server.close();
+                done();
+            });
+        });
+    });
+
+    it('will try to parse json in "force" mode, regardless of the header', function (done) {
+
+        var server = Http.createServer(function (req, res) {
+
+            res.writeHead(200, { 'Content-Type': 'text/plain' });
+            res.end(JSON.stringify({ foo: 'bar' }));
+        });
+
+        server.listen(0, function () {
+
+            var port = server.address().port;
+            var options = {
+                json: 'force'
+            };
+
+            Wreck.get('http://localhost:' + port, options, function (err, res, payload) {
+
+                expect(err).to.not.exist();
+                expect(res.statusCode).to.equal(200);
+                expect(payload).to.not.equal(null);
+                expect(payload).to.deep.equal({
+                    foo: 'bar'
+                });
+                server.close();
+                done();
+            });
+        });
+    });
+
+    it('will error on invalid json received in "force" mode', function (done) {
+
+        var server = Http.createServer(function (req, res) {
+
+            res.writeHead(200, { 'Content-Type': 'text/plain' });
+            res.end('ok');
+        });
+
+        server.listen(0, function () {
+
+            var port = server.address().port;
+            var options = {
+                json: 'force'
+            };
+
+            Wreck.get('http://localhost:' + port, options, function (err, res, payload) {
+
+                expect(err).to.exist();
                 server.close();
                 done();
             });


### PR DESCRIPTION
Trumps #68 because that will still look at the content-type header even in 'force' mode. My change does not and tries to parse regardless of the header. Which was the goal of #67 I believe.