### PR TITLE
Fix issues with node 0.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: node_js
 
 node_js:
-  - 0.10
+  - "0.10"
+  - "0.12"
+  - iojs
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -80,10 +80,6 @@ exports.request = function (method, url, options, callback, _trace) {
     var finish = function (err, res) {
 
         if (!callback || err) {
-            if (res) {
-                res.destroy();
-            }
-
             req.abort();
         }
 
@@ -176,6 +172,27 @@ exports.request = function (method, url, options, callback, _trace) {
 
         req.write(options.payload);
     }
+
+    // Custom abort method to detect early aborts
+
+    var _abort = req.abort;
+    var aborted = false;
+    req.abort = function () {
+
+        if (!aborted && !req.res && !req.socket) {
+            process.nextTick(function () {
+
+                // Fake an ECONNRESET error
+
+                var error = new Error('socket hang up');
+                error.code = 'ECONNRESET';
+                finish(error);
+            });
+        }
+
+        aborted = true;
+        return _abort.call(req);
+    };
 
     // Finalize request
 

--- a/test/index.js
+++ b/test/index.js
@@ -667,6 +667,28 @@ describe('request()', function () {
         });
     });
 
+    it('in-progress requests can be aborted', function (done) {
+
+        var wreck;
+        var server = Http.createServer(function (req, res) {
+
+            res.writeHead(200);
+            res.end();
+
+            wreck.abort();
+        });
+
+        server.listen(0, function () {
+
+            wreck = Wreck.request('get', 'http://localhost:' + server.address().port, {}, function (err) {
+
+                expect(err).to.exist();
+                expect(err.code).to.equal('ECONNRESET');
+                done();
+            });
+        });
+    });
+
     it('uses agent option', function (done) {
 
         var agent = new Http.Agent();

--- a/test/index.js
+++ b/test/index.js
@@ -211,7 +211,7 @@ describe('request()', function () {
 
     it('requests an https resource with secure protocol set', function (done) {
 
-        Wreck.request('get', 'https://google.com', { rejectUnauthorized: true, secureProtocol: 'SSLv3_method' }, function (err, res) {
+        Wreck.request('get', 'https://google.com', { rejectUnauthorized: true, secureProtocol: 'SSLv23_method' }, function (err, res) {
 
             expect(err).to.not.exist();
             Wreck.read(res, null, function (err, body) {


### PR DESCRIPTION
The main issue is that calls to `abort()` can now cause the stream to stop without any notification at all. As a consequence, I have implemented a workaround that intercepts all calls to `abort()`.

The SSL test fix might be specific to my homebrew 0.12 install, though it should not cause any issues.
