### PR TITLE
Added uri to event payloads.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ var options = {
 var optionalCallback = function (err, res) {
 
     /* handle err if it exists, in which case res will be undefined */
-    
+
     // buffer the response stream
     Wreck.read(res, null, function (err, body) {
         /* do stuff */
@@ -185,7 +185,7 @@ var  result = Wreck.parseCacheControl('private, max-age=0, no-cache');
 
 Object that contains the agents for pooling connections for `http` and `https`.  The properties are `http`, `https`, and
 `httpsAllowUnauthorized` which is an `https` agent with `rejectUnauthorized` set to true.  All agents have `maxSockets`
-configured to `Infinity`.  They are each instances of the node.js 
+configured to `Infinity`.  They are each instances of the node.js
 [Agent](http://nodejs.org/api/http.html#http_class_http_agent) and expose the standard properties.
 
 For example, the following code demonstrates changing `maxSockets` on the `http` agent.
@@ -202,8 +202,13 @@ For example, the following code demonstrates changing `maxSockets` on the `http`
 #### `response`
 
 The response event is always emitted for any request that *wreck* makes.  The handler should accept the following
-arguments `(error, request, response, start)`.  This event is useful for logging all requests that go through *wreck*.  
-The error and response arguments can be undefined depending on if an error occurs.  Please be aware that if multiple 
-modules are depending on the same cached *wreck* module that this event can fire for each request made across all 
+arguments `(error, request, response, start, uri)` where:  
+  -`error` - a Boom error
+  - `request` - the raw `ClientHttp` request object
+  - `response` - the raw `IncomingMessage#` response object
+  - `uri` - the result of `Url.parse(uri)`. This will provide information about the resource requested.
+This event is useful for logging all requests that go through *wreck*.  
+The error and response arguments can be undefined depending on if an error occurs.  Please be aware that if multiple
+modules are depending on the same cached *wreck* module that this event can fire for each request made across all
 modules.  The start argument is the timestamp when the request was started.  This can be useful for determining how long
 it takes *wreck* to get a response back and processed.

--- a/README.md
+++ b/README.md
@@ -202,11 +202,12 @@ For example, the following code demonstrates changing `maxSockets` on the `http`
 #### `response`
 
 The response event is always emitted for any request that *wreck* makes.  The handler should accept the following
-arguments `(error, request, response, start, uri)` where:  
-  -`error` - a Boom error
+arguments `(error, request, response, start, uri)` where:
+  - `error` - a Boom error
   - `request` - the raw `ClientHttp` request object
-  - `response` - the raw `IncomingMessage#` response object
+  - `response` - the raw `IncomingMessage` response object
   - `uri` - the result of `Url.parse(uri)`. This will provide information about the resource requested.
+
 This event is useful for logging all requests that go through *wreck*.  
 The error and response arguments can be undefined depending on if an error occurs.  Please be aware that if multiple
 modules are depending on the same cached *wreck* module that this event can fire for each request made across all

--- a/lib/index.js
+++ b/lib/index.js
@@ -100,7 +100,7 @@ internals.Client.prototype.request = function (method, url, options, callback, _
         req.removeListener('error', onError);
         req.on('error', Hoek.ignore);
         clearTimeout(timeoutId);
-        self.emit('response', err, req, res, start);
+        self.emit('response', err, req, res, start, uri);
 
         if (callback) {
             return callback(err, res);

--- a/test/index.js
+++ b/test/index.js
@@ -1524,20 +1524,22 @@ describe('Events', function () {
 
     it('emits response event when wreck is finished', function (done) {
 
-        Wreck.once('response', function (err, req, res, start) {
-
-            expect(err).to.not.exist();
-            expect(req).to.exist();
-            expect(res).to.exist();
-            expect(typeof start).to.equal('number');
-            done();
-        });
-
         var server = Http.createServer(function (req, res) {
 
             res.writeHead(200);
             res.end('ok');
         });
+
+        Wreck.once('response', function (err, req, res, start, uri) {
+
+            expect(err).to.not.exist();
+            expect(req).to.exist();
+            expect(res).to.exist();
+            expect(typeof start).to.equal('number');
+            expect(uri.href).to.equal('http://localhost:' + server.address().port + '/');
+            done();
+        });
+
 
         server.listen(0, function () {
 


### PR DESCRIPTION
Unless I'm completely missing it somewhere, there isn't a way to get the full URL requested with `Wreck` in the "response" event. Added `uri` object to the "response" payload. This will let you log more detailed information about the upstream request.

Related to https://github.com/hapijs/good/issues/334