### PR TITLE
add support for defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,15 @@ var method = 'GET'; // GET, POST, PUT, DELETE
 var uri    = 'https://google.com/';
 var readableStream = Wreck.toReadableStream('foo=bar');
 
+var wreck = Wreck.defaults({
+    headers: { 'x-foo-bar': 123 }
+});
+
+// cascading example -- does not alter `wreck`
+var wreckWithTimeout = wreck.defaults({
+    timeout: 5
+});
+
 // all attributes are optional
 var options = {
     payload:   readableStream || 'foo=bar' || new Buffer('foo=bar'),
@@ -48,8 +57,13 @@ var optionalCallback = function (err, res) {
     });
 };
 
-var req = Wreck.request(method, uri, options, optionalCallback);
+var req = wreck.request(method, uri, options, optionalCallback);
 ```
+
+### `defaults(options)`
+
+Returns a *new* instance of Wreck which merges the provided `options` with those provided on a per-request basis. You can call defaults repeatedly to build up multiple http clients.
+- `options` - Config object containing settings for both `request` and `read` operations.
 
 ### `request(method, uri, [options, [callback]])`
 
@@ -210,7 +224,7 @@ arguments `(error, request, response, start, uri)` where:
   - `uri` - the result of `Url.parse(uri)`. This will provide information about the resource requested.  Also includes
     the headers and method.
 
-This event is useful for logging all requests that go through *wreck*.  
+This event is useful for logging all requests that go through *wreck*.
 The error and response arguments can be undefined depending on if an error occurs.  Please be aware that if multiple
 modules are depending on the same cached *wreck* module that this event can fire for each request made across all
 modules.  The start argument is the timestamp when the request was started.  This can be useful for determining how long

--- a/lib/index.js
+++ b/lib/index.js
@@ -20,7 +20,7 @@ var internals = {};
 
 // new instance is exported as module.exports
 
-internals.Client = function () {
+internals.Client = function (defaults) {
 
     Events.EventEmitter.call(this);
 
@@ -29,16 +29,24 @@ internals.Client = function () {
         http: new Http.Agent({ maxSockets: Infinity }),
         httpsAllowUnauthorized: new Https.Agent({ maxSockets: Infinity, rejectUnauthorized: false })
     };
+
+    this._defaults = defaults || {};
 };
 
 Hoek.inherits(internals.Client, Events.EventEmitter);
+
+internals.Client.prototype.defaults = function (options) {
+
+    options = Hoek.applyToDefaultsWithShallow(options, this._defaults, ['agent', 'payload', 'downstreamRes']);
+    return new internals.Client(options);
+};
 
 
 internals.Client.prototype.request = function (method, url, options, callback, _trace) {
 
     var self = this;
 
-    options = options || {};
+    options = Hoek.applyToDefaultsWithShallow(options || {}, this._defaults, ['agent', 'payload', 'downstreamRes']);
 
     Hoek.assert(options.payload === null || options.payload === undefined || typeof options.payload === 'string' ||
         options.payload instanceof Stream || Buffer.isBuffer(options.payload),
@@ -220,7 +228,8 @@ internals.Client.prototype.request = function (method, url, options, callback, _
 
 internals.Client.prototype.read = function (res, options, callback) {
 
-    options = options || {};
+    options = Hoek.applyToDefaultsWithShallow(options || {}, this._defaults, ['agent', 'payload', 'downstreamRes']);
+
 
     // Set stream timeout
 

--- a/test/index.js
+++ b/test/index.js
@@ -1595,4 +1595,56 @@ describe('Events', function () {
             });
         });
     });
+
+    it('rejects attempts to use defaults without an options hash', function (done) {
+
+        var fn = function () {
+
+            Wreck.defaults();
+        };
+
+        expect(fn).to.throw();
+        done();
+    });
+
+    it('respects defaults without bleeding across instances', function (done) {
+
+        var req;
+
+        var optionsA = { headers: { foo: 123 } };
+        var optionsB = { headers: { bar: 321 } };
+
+        var wreckA = Wreck.defaults(optionsA);
+        var wreckB = Wreck.defaults(optionsB);
+        var wreckAB = wreckA.defaults(optionsB);
+
+        // var agent = new Http.Agent();
+        // expect(Object.keys(agent.sockets).length).to.equal(0);
+
+        req = wreckA.request('get', 'http://localhost/', { headers: { banana: 911 } }, function (err, res) {
+
+            expect(req._headers.banana).to.exist();
+            expect(req._headers.foo).to.exist();
+            expect(req._headers.bar).to.not.exist();
+
+            req = wreckB.request('get', 'http://localhost/', { headers: { banana: 911 } }, function (err, res) {
+
+                expect(req._headers.banana).to.exist();
+                expect(req._headers.foo).to.not.exist();
+                expect(req._headers.bar).to.exist();
+
+                req = wreckAB.request('get', 'http://localhost/', { headers: { banana: 911 } }, function (err, res) {
+
+                    expect(req._headers.banana).to.exist();
+                    expect(req._headers.foo).to.exist();
+                    expect(req._headers.bar).to.exist();
+
+                    done();
+                });
+            });
+
+        });
+
+
+    });
 });


### PR DESCRIPTION
## reason
One of my favorite features of [node-request](https://github.com/request/request) is using [defaults](https://github.com/request/request#requestdefaultsoptions) to create a mostly configured instance ... but since it never seems to work right, I decided to switch to wreck and implement the behavior here instead :+1: 

## usage
```js
var wreck = Wreck.defaults({
  headers: {
    'authorization': 'asdf-1234-qwer-5678-zxcv',
    'host': 'api.foo.com',
    'timeout': 3000,
    'accept': 'application/json',
  }
});

wreck.get('/apps', function(err, res, payload) {
  /* stuff */
});
```