### PR TITLE
add support for the `baseUrl` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ var readableStream = Wreck.toReadableStream('foo=bar');
 
 // all attributes are optional
 var options = {
+    baseUrl:   fully qualified uri string used as the base url. Most useful with `request.defaults`, for example when you want to do many requests to the same domain.  If `baseUrl` is `https://example.com/api/`, then requesting `/end/point?test=true` will fetch `https://example.com/api/end/point?test=true`. When `baseUrl` is given, `uri` must also be a string.
     payload:   readableStream || 'foo=bar' || new Buffer('foo=bar'),
     headers:   { /* http headers */ },
     redirects: 3,
@@ -210,7 +211,7 @@ arguments `(error, request, response, start, uri)` where:
   - `uri` - the result of `Url.parse(uri)`. This will provide information about the resource requested.  Also includes
     the headers and method.
 
-This event is useful for logging all requests that go through *wreck*.  
+This event is useful for logging all requests that go through *wreck*.
 The error and response arguments can be undefined depending on if an error occurs.  Please be aware that if multiple
 modules are depending on the same cached *wreck* module that this event can fire for each request made across all
 modules.  The start argument is the timestamp when the request was started.  This can be useful for determining how long

--- a/lib/index.js
+++ b/lib/index.js
@@ -48,6 +48,23 @@ internals.Client.prototype.request = function (method, url, options, callback, _
         'options.agent cannot be set to an Agent at the same time as options.rejectUnauthorized is set');
 
     // Setup request
+    if (options.baseUrl) {
+
+        // Handle all cases to make sure that there's only one slash between
+        // baseUrl and uri.
+        var baseUrlEndsWithSlash = options.baseUrl.lastIndexOf('/') === options.baseUrl.length - 1;
+        var uriStartsWithSlash = url.indexOf('/') === 0;
+
+        if (baseUrlEndsWithSlash && uriStartsWithSlash) {
+            url = options.baseUrl + url.slice(1);
+        } else if (baseUrlEndsWithSlash || uriStartsWithSlash) {
+            url = options.baseUrl + url;
+        } else if (url === '') {
+            url = options.baseUrl;
+        } else {
+            url = options.baseUrl + '/' + url;
+        }
+    }
 
     var uri = Url.parse(url);
     var timeoutId;

--- a/test/index.js
+++ b/test/index.js
@@ -960,6 +960,54 @@ describe('request()', function () {
     });
 });
 
+describe('baseUrl', function () {
+
+    it('uses baseUrl option with trailing slash and uri is prefixed with a slash', function (done) {
+
+        var r = Wreck.request('get', '/foo', { baseUrl: 'http://localhost/' }, function (err, res) {
+
+            expect(r._headers.host).to.equal('localhost');
+            done();
+        });
+    });
+
+    it('uses baseUrl option without trailing slash and uri is prefixed with a slash', function (done) {
+
+        var r = Wreck.request('get', '/foo', { baseUrl: 'http://localhost' }, function (err, res) {
+
+            expect(r._headers.host).to.equal('localhost');
+            done();
+        });
+    });
+
+    it('uses baseUrl option with trailing slash and uri is prefixed without a slash', function (done) {
+
+        var r = Wreck.request('get', 'foo', { baseUrl: 'http://localhost/' }, function (err, res) {
+
+            expect(r._headers.host).to.equal('localhost');
+            done();
+        });
+    });
+
+    it('uses baseUrl option without trailing slash and uri is prefixed without a slash', function (done) {
+
+        var r = Wreck.request('get', 'foo', { baseUrl: 'http://localhost' }, function (err, res) {
+
+            expect(r._headers.host).to.equal('localhost');
+            done();
+        });
+    });
+
+    it('uses baseUrl option when uri is an empty string', function (done) {
+
+        var r = Wreck.request('get', '', { baseUrl: 'http://localhost' }, function (err, res) {
+
+            expect(r._headers.host).to.equal('localhost');
+            done();
+        });
+    });
+});
+
 describe('read()', function () {
 
     it('handles errors with a boom response', function (done) {
@@ -1146,7 +1194,6 @@ describe('read()', function () {
             done();
         });
     });
-
 });
 
 describe('parseCacheControl()', function () {


### PR DESCRIPTION
## README.changes
```js
// all attributes are optional
var options = {
    baseUrl:   fully qualified uri string used as the base url. Most useful with `request.defaults`, for example when you want to do many requests to the same domain.  If `baseUrl` is `https://example.com/api/`, then requesting `/end/point?test=true` will fetch `https://example.com/api/end/point?test=true`. When `baseUrl` is given, `uri` must also be a string.
    payload:   readableStream || 'foo=bar' || new Buffer('foo=bar'),
    /* ... */
};
```

## Example
```js
Wreck.request(method, '/apps', { baseUrl: 'https://api.heroku.com' }, optionalCallback);
```

## Example [built ontop of #85]
```js
const apiClient = Wreck.defaults({
  baseUrl: `https://api.heroku.com/`,
  headers: {
    'x-foo-bar': 12345
  }
});

var f = apiClient('/apps', function(err,body) {
    expect(f._headers.host).to.equal('api.heroku.com');
    expect(f._headers['x-foo-bar']).to.equal(12345);
});
```