### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,10 +23,5 @@
   "scripts": {
     "test": "make test-cov"
   },
-  "licenses": [
-    {
-      "type": "BSD",
-      "url": "http://github.com/hapijs/wreck/raw/master/LICENSE"
-    }
-  ]
+  "license": "BSD-3-Clause"
 }


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/