### PR TITLE
Fix missing options when redirecting

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -77,6 +77,7 @@ internals.Client.prototype.request = function (method, url, options, callback, _
 
     if (options.baseUrl) {
         url = internals.resolveUrl(options.baseUrl, url);
+        delete options.baseUrl;
     }
 
     var uri = Url.parse(url);
@@ -176,11 +177,10 @@ internals.Client.prototype.request = function (method, url, options, callback, _
             location = Url.resolve(uri.href, location);
         }
 
-        var redirectOptions = {
-            headers: options.headers,
-            payload: shadow || options.payload,         // shadow must be ready at this point if set
-            redirects: --redirects
-        };
+        var redirectOptions = Hoek.cloneWithShallow(options, ['agent', 'payload', 'downstreamRes']);
+
+        redirectOptions.payload = shadow || options.payload;         // shadow must be ready at this point if set
+        redirectOptions.redirects = --redirects;
 
         return self.request(redirectMethod, location, redirectOptions, finish, _trace);
     };
@@ -192,6 +192,7 @@ internals.Client.prototype.request = function (method, url, options, callback, _
 
             return finish(Boom.gatewayTimeout('Client request timeout'));
         }, options.timeout);
+        delete options.timeout;
     }
 
     // Write payload

--- a/test/index.js
+++ b/test/index.js
@@ -274,6 +274,40 @@ describe('request()', function () {
         });
     });
 
+    it('applies rejectUnauthorized when redirected', function (done) {
+
+        var httpsOptions = {
+            key: '-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAKCAQEA0UqyXDCqWDKpoNQQK/fdr0OkG4gW6DUafxdufH9GmkX/zoKz\ng/SFLrPipzSGINKWtyMvo7mPjXqqVgE10LDI3VFV8IR6fnART+AF8CW5HMBPGt/s\nfQW4W4puvBHkBxWSW1EvbecgNEIS9hTGvHXkFzm4xJ2e9DHp2xoVAjREC73B7JbF\nhc5ZGGchKw+CFmAiNysU0DmBgQcac0eg2pWoT+YGmTeQj6sRXO67n2xy/hA1DuN6\nA4WBK3wM3O4BnTG0dNbWUEbe7yAbV5gEyq57GhJIeYxRvveVDaX90LoAqM4cUH06\n6rciON0UbDHV2LP/JaH5jzBjUyCnKLLo5snlbwIDAQABAoIBAQDJm7YC3pJJUcxb\nc8x8PlHbUkJUjxzZ5MW4Zb71yLkfRYzsxrTcyQA+g+QzA4KtPY8XrZpnkgm51M8e\n+B16AcIMiBxMC6HgCF503i16LyyJiKrrDYfGy2rTK6AOJQHO3TXWJ3eT3BAGpxuS\n12K2Cq6EvQLCy79iJm7Ks+5G6EggMZPfCVdEhffRm2Epl4T7LpIAqWiUDcDfS05n\nNNfAGxxvALPn+D+kzcSF6hpmCVrFVTf9ouhvnr+0DpIIVPwSK/REAF3Ux5SQvFuL\njPmh3bGwfRtcC5d21QNrHdoBVSN2UBLmbHUpBUcOBI8FyivAWJhRfKnhTvXMFG8L\nwaXB51IZAoGBAP/E3uz6zCyN7l2j09wmbyNOi1AKvr1WSmuBJveITouwblnRSdvc\nsYm4YYE0Vb94AG4n7JIfZLKtTN0xvnCo8tYjrdwMJyGfEfMGCQQ9MpOBXAkVVZvP\ne2k4zHNNsfvSc38UNSt7K0HkVuH5BkRBQeskcsyMeu0qK4wQwdtiCoBDAoGBANF7\nFMppYxSW4ir7Jvkh0P8bP/Z7AtaSmkX7iMmUYT+gMFB5EKqFTQjNQgSJxS/uHVDE\nSC5co8WGHnRk7YH2Pp+Ty1fHfXNWyoOOzNEWvg6CFeMHW2o+/qZd4Z5Fep6qCLaa\nFvzWWC2S5YslEaaP8DQ74aAX4o+/TECrxi0z2lllAoGAdRB6qCSyRsI/k4Rkd6Lv\nw00z3lLMsoRIU6QtXaZ5rN335Awyrfr5F3vYxPZbOOOH7uM/GDJeOJmxUJxv+cia\nPQDflpPJZU4VPRJKFjKcb38JzO6C3Gm+po5kpXGuQQA19LgfDeO2DNaiHZOJFrx3\nm1R3Zr/1k491lwokcHETNVkCgYBPLjrZl6Q/8BhlLrG4kbOx+dbfj/euq5NsyHsX\n1uI7bo1Una5TBjfsD8nYdUr3pwWltcui2pl83Ak+7bdo3G8nWnIOJ/WfVzsNJzj7\n/6CvUzR6sBk5u739nJbfgFutBZBtlSkDQPHrqA7j3Ysibl3ZIJlULjMRKrnj6Ans\npCDwkQKBgQCM7gu3p7veYwCZaxqDMz5/GGFUB1My7sK0hcT7/oH61yw3O8pOekee\nuctI1R3NOudn1cs5TAy/aypgLDYTUGQTiBRILeMiZnOrvQQB9cEf7TFgDoRNCcDs\nV/ZWiegVB/WY7H0BkCekuq5bHwjgtJTpvHGqQ9YD7RhE8RSYOhdQ/Q==\n-----END RSA PRIVATE KEY-----\n',
+            cert: '-----BEGIN CERTIFICATE-----\nMIIDBjCCAe4CCQDvLNml6smHlTANBgkqhkiG9w0BAQUFADBFMQswCQYDVQQGEwJV\nUzETMBEGA1UECAwKU29tZS1TdGF0ZTEhMB8GA1UECgwYSW50ZXJuZXQgV2lkZ2l0\ncyBQdHkgTHRkMB4XDTE0MDEyNTIxMjIxOFoXDTE1MDEyNTIxMjIxOFowRTELMAkG\nA1UEBhMCVVMxEzARBgNVBAgMClNvbWUtU3RhdGUxITAfBgNVBAoMGEludGVybmV0\nIFdpZGdpdHMgUHR5IEx0ZDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEB\nANFKslwwqlgyqaDUECv33a9DpBuIFug1Gn8Xbnx/RppF/86Cs4P0hS6z4qc0hiDS\nlrcjL6O5j416qlYBNdCwyN1RVfCEen5wEU/gBfAluRzATxrf7H0FuFuKbrwR5AcV\nkltRL23nIDRCEvYUxrx15Bc5uMSdnvQx6dsaFQI0RAu9weyWxYXOWRhnISsPghZg\nIjcrFNA5gYEHGnNHoNqVqE/mBpk3kI+rEVzuu59scv4QNQ7jegOFgSt8DNzuAZ0x\ntHTW1lBG3u8gG1eYBMquexoSSHmMUb73lQ2l/dC6AKjOHFB9Ouq3IjjdFGwx1diz\n/yWh+Y8wY1Mgpyiy6ObJ5W8CAwEAATANBgkqhkiG9w0BAQUFAAOCAQEAoSc6Skb4\ng1e0ZqPKXBV2qbx7hlqIyYpubCl1rDiEdVzqYYZEwmst36fJRRrVaFuAM/1DYAmT\nWMhU+yTfA+vCS4tql9b9zUhPw/IDHpBDWyR01spoZFBF/hE1MGNpCSXXsAbmCiVf\naxrIgR2DNketbDxkQx671KwF1+1JOMo9ffXp+OhuRo5NaGIxhTsZ+f/MA4y084Aj\nDI39av50sTRTWWShlN+J7PtdQVA5SZD97oYbeUeL7gI18kAJww9eUdmT0nEjcwKs\nxsQT1fyKbo7AlZBY4KSlUMuGnn0VnAsB9b+LxtXlDfnjyM8bVQx1uAfRo0DO8p/5\n3J5DTjAU55deBQ==\n-----END CERTIFICATE-----\n'
+        };
+
+        var gen = 0;
+        var server = Https.createServer(httpsOptions, function (req, res) {
+
+            if (!gen++) {
+                res.writeHead(301, { 'Location': '/' });
+                res.end();
+            }
+            else {
+                res.writeHead(200, { 'Content-Type': 'text/plain' });
+                res.end();
+            }
+        });
+
+        server.listen(0, function (err) {
+
+            expect(err).to.not.exist();
+
+            Wreck.request('get', 'https://localhost:' + server.address().port, { redirects: 1, rejectUnauthorized: false }, function (err, res) {
+
+                expect(err).to.not.exist();
+                expect(res.statusCode).to.equal(200);
+                server.close();
+                done();
+            });
+        });
+    });
+
     it('requests a resource with downstream dependency', function (done) {
 
         var up = Http.createServer(function (req, res) {
@@ -384,6 +418,7 @@ describe('request()', function () {
                 res.end();
             }
             else {
+                expect(req.url).to.equal('/');
                 res.writeHead(200, { 'Content-Type': 'text/plain' });
                 res.end(payload);
             }
@@ -699,6 +734,43 @@ describe('request()', function () {
 
             expect(Object.keys(agent.sockets).length).to.equal(1);
             done();
+        });
+    });
+
+    it('applies agent option when redirected', function (done) {
+
+        var gen = 0;
+        var server = Http.createServer(function (req, res) {
+
+            if (!gen++) {
+                res.writeHead(301, { 'Location': '/' });
+                res.end();
+            }
+            else {
+                res.writeHead(200, { 'Content-Type': 'text/plain' });
+                res.end();
+            }
+        });
+
+        var agent = new Http.Agent();
+        var requestCount = 0;
+        var addRequest = agent.addRequest;
+        agent.addRequest = function () {
+
+            requestCount++;
+            addRequest.apply(agent, arguments);
+        };
+
+        server.listen(0, function () {
+
+            Wreck.request('get', 'http://localhost:' + server.address().port, { redirects: 1, agent: agent }, function (err, res) {
+
+                expect(err).to.not.exist();
+                expect(res.statusCode).to.equal(200);
+                expect(requestCount).to.equal(2);
+                server.close();
+                done();
+            });
         });
     });
 


### PR DESCRIPTION
The `rejectUnauthorized`, `agent`, and `secureProtocol` options were discarded on redirects.

This is fixed by copying all options and ensuring one-time options are removed once applied.

I have added tests for the `rejectUnauthorized` and `agent` options but I did not find a way to test the `secureProtocol` option.

Note that this is actually a security fix, as the `secureProtocol` option is currently ignored on any redirected requests.
