### PR TITLE
Add a beforeRedirect callback option

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ var options = {
     payload:   readableStream || 'foo=bar' || new Buffer('foo=bar'),
     headers:   { /* http headers */ },
     redirects: 3,
+    beforeRedirect: function (redirectMethod, statusCode, location, redirectOptions) {},
     redirected: function (statusCode, location, req) {},
     timeout:   1000,    // 1 second, default: unlimited
     maxBytes:  1048576, // 1 MB, default: unlimited
@@ -83,6 +84,11 @@ Initiate an HTTP request.
       whether the client should reject a response from a server with invalid certificates.  This cannot be set at the
       same time as the `agent` option is set.
     - `redirects` - The maximum number of redirects to follow.
+    - `beforeRedirect` - A callback function that is called before a redirect is triggered, using the signature function (redirectMethod, statusCode, location, redirectOptions) where:
+      - `redirectMethod` - A string specifying the redirect method.
+      - `statusCode` - HTTP status code of the response that triggered the redirect.
+      - `location` - The redirect location string.
+      - `redirectOptions` - Options that will be applied to the redirect request.
     - `redirected` - A callback function that is called when a redirect was triggered, using the signature `function (statusCode, location, req)` where:
       - `statusCode` - HTTP status code of the response that triggered the redirect.
       - `location` - The redirected location string.

--- a/lib/index.js
+++ b/lib/index.js
@@ -78,7 +78,7 @@ internals.Client.prototype.request = function (method, url, options, callback, _
 
     Hoek.assert(options.beforeRedirect === undefined || options.beforeRedirect === null || typeof options.beforeRedirect === 'function',
         'options.beforeRedirect must be a function');
-    
+
     Hoek.assert(options.redirected === undefined || options.redirected === null || typeof options.redirected === 'function',
         'options.redirected must be a function');
 
@@ -190,7 +190,7 @@ internals.Client.prototype.request = function (method, url, options, callback, _
 
         redirectOptions.payload = shadow || options.payload;         // shadow must be ready at this point if set
         redirectOptions.redirects = --redirects;
-        
+
         if (options.beforeRedirect) {
             options.beforeRedirect(redirectMethod, statusCode, location, redirectOptions);
         }

--- a/lib/index.js
+++ b/lib/index.js
@@ -17,7 +17,7 @@ var Tap = require('./tap');
 
 var internals = {
     jsonRegex: /^application\/[a-z.+-]*json$/,
-    shallowOptions: ['agent', 'payload', 'downstreamRes', 'redirected']
+    shallowOptions: ['agent', 'payload', 'downstreamRes', 'beforeRedirect', 'redirected']
 };
 
 
@@ -76,6 +76,9 @@ internals.Client.prototype.request = function (method, url, options, callback, _
     Hoek.assert((options.agent === undefined || options.agent === null) || (typeof options.rejectUnauthorized !== 'boolean'),
         'options.agent cannot be set to an Agent at the same time as options.rejectUnauthorized is set');
 
+    Hoek.assert(options.beforeRedirect === undefined || options.beforeRedirect === null || typeof options.beforeRedirect === 'function',
+        'options.beforeRedirect must be a function');
+    
     Hoek.assert(options.redirected === undefined || options.redirected === null || typeof options.redirected === 'function',
         'options.redirected must be a function');
 
@@ -187,6 +190,10 @@ internals.Client.prototype.request = function (method, url, options, callback, _
 
         redirectOptions.payload = shadow || options.payload;         // shadow must be ready at this point if set
         redirectOptions.redirects = --redirects;
+        
+        if (options.beforeRedirect) {
+            options.beforeRedirect(redirectMethod, statusCode, location, redirectOptions);
+        }
 
         var redirectReq = self.request(redirectMethod, location, redirectOptions, finish, _trace);
 


### PR DESCRIPTION
PR based on https://github.com/hapijs/wreck/pull/97.

I've added a new option - `beforeRedirect` - which is called before redirection is made. My use case for this was that we send all requests to the same URL but modify header `Host` to set the request target (we use Consul). Example of `beforeRedirect` callback from http://github.com/Wikia/mercury:

```
/**
 * We send requests to Consul URL and the target wiki is passed in the Host header.
 * When Wreck gets a redirection response it updates URL only, not headers.
 * That's why we need to update Host header manually.
 *
 * @param redirectMethod
 * @param statusCode
 * @param location
 * @param redirectOptions
 */
var beforeRedirect = (redirectMethod: string, statusCode: number, location: string, redirectOptions: any): void => {
	var redirectHost: string = Url.parse(location).hostname;

	if (redirectHost) {
		redirectOptions.headers.Host = redirectHost;
	}
};
```