### PR TITLE
Add tests for defaults

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -66,7 +66,7 @@ internals.resolveUrl = function (baseUrl, path) {
 
 internals.Client.prototype.request = function (method, url, options, callback, _trace) {
 
-    options = Hoek.applyToDefaultsWithShallow(options || {}, this._defaults, internals.shallowOptions);
+    options = Hoek.applyToDefaultsWithShallow(this._defaults, options || {}, internals.shallowOptions);
 
     Hoek.assert(options.payload === null || options.payload === undefined || typeof options.payload === 'string' ||
         options.payload instanceof Stream || Buffer.isBuffer(options.payload),

--- a/test/index.js
+++ b/test/index.js
@@ -1957,6 +1957,9 @@ describe('Events', () => {
             });
         });
     });
+});
+
+describe('Defaults', () => {
 
     it('rejects attempts to use defaults without an options hash', (done) => {
 

--- a/test/index.js
+++ b/test/index.js
@@ -2005,4 +2005,20 @@ describe('Defaults', () => {
             });
         });
     });
+
+    it('applies defaults correctly to requests', (done) => {
+
+        const optionsA = { headers: { Accept: 'foo', 'Test': 123 } };
+        const optionsB = { headers: { Accept: 'bar' } };
+
+        const wreckA = Wreck.defaults(optionsA);
+
+        const req1 = wreckA.request('get', 'http://localhost/', optionsB, (err) => {
+
+            expect(req1._headers.accept).to.equal('bar');
+            expect(req1._headers.test).to.equal(123);
+
+            done();
+        });
+    });
 });


### PR DESCRIPTION
This PR adds tests for checking that Defaults are actually applied correctly; Turns out we weren't quite at 100% Code Coverage, it just appeared like we were.

See also: #117