### PR TITLE
lowercase the content-length header

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -95,7 +95,7 @@ internals.Client.prototype.request = function (method, url, options, callback, _
         (typeof options.payload === 'string' || Buffer.isBuffer(options.payload))) {
 
         uri.headers = Hoek.clone(uri.headers) || {};
-        uri.headers['Content-Length'] = Buffer.isBuffer(options.payload) ? options.payload.length : Buffer.byteLength(options.payload);
+        uri.headers['content-length'] = Buffer.isBuffer(options.payload) ? options.payload.length : Buffer.byteLength(options.payload);
     }
 
     let redirects = (options.hasOwnProperty('redirects') ? options.redirects : false);      // Needed to allow 0 as valid value when passed recursively

--- a/lib/index.js
+++ b/lib/index.js
@@ -92,7 +92,8 @@ internals.Client.prototype.request = function (method, url, options, callback, _
 
     const payloadSupported = (uri.method !== 'GET' && uri.method !== 'HEAD' && options.payload !== null && options.payload !== undefined);
     if (payloadSupported &&
-        (typeof options.payload === 'string' || Buffer.isBuffer(options.payload))) {
+        (typeof options.payload === 'string' || Buffer.isBuffer(options.payload)) &&
+        (!uri.headers || !uri.headers['content-length'])) {
 
         uri.headers = Hoek.clone(uri.headers) || {};
         uri.headers['content-length'] = Buffer.isBuffer(options.payload) ? options.payload.length : Buffer.byteLength(options.payload);

--- a/test/index.js
+++ b/test/index.js
@@ -107,6 +107,32 @@ describe('request()', () => {
         });
     });
 
+    it('should not overwrite content-length if it is already in the headers', (done) => {
+
+        const server = Http.createServer((req, res) => {
+
+            expect(req.headers['content-length']).to.equal('16390');
+            res.writeHead(200, { 'Content-Type': 'text/plain' });
+            req.pipe(res);
+        });
+
+        server.listen(0, () => {
+
+            const options = { payload: internals.payload, headers: { 'content-length': '16390' } };
+            Wreck.request('post', 'http://localhost:' + server.address().port, options, (err, res) => {
+
+                expect(err).to.not.exist();
+                Wreck.read(res, null, (err, body) => {
+
+                    expect(err).to.not.exist();
+                    expect(body.toString()).to.equal(internals.payload);
+                    server.close();
+                    done();
+                });
+            });
+        });
+    });
+
     it('requests a POST resource with headers', (done) => {
 
         const server = Http.createServer((req, res) => {


### PR DESCRIPTION
I ran into duplicate content-lengths being set when h2o2 passThrough is set to true and the payload being proxied through is a buffer. `content-length` is being proxied and then wreck sets `Content-Length`. I guess this would be fine except we use nock for testing and it tries to lowercase all the header keys manually and blows up on duplicates.

I guess another solution could be to not set `content-length` if it is already set.