### PR TITLE
A missing callback on request still allows client requests to work

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -147,7 +147,6 @@ internals.Client.prototype.request = function (method, url, options, callback, _
         err.trace = _trace;
         return finishOnce(Boom.badGateway('Client request error', err));
     };
-
     req.once('error', onError);
 
     const onResponse = (res) => {
@@ -201,7 +200,7 @@ internals.Client.prototype.request = function (method, url, options, callback, _
 
     const finish = (err, res) => {
 
-        if (!callback || err) {
+        if (err) {
             req.abort();
         }
 
@@ -228,29 +227,6 @@ internals.Client.prototype.request = function (method, url, options, callback, _
         delete options.timeout;
     }
 
-    // Write payload
-
-    if (payloadSupported) {
-        if (options.payload instanceof Stream) {
-            let stream = options.payload;
-
-            if (redirects) {
-                const collector = new Tap();
-                collector.once('finish', () => {
-
-                    shadow = collector.collect();
-                });
-
-                stream = options.payload.pipe(collector);
-            }
-
-            stream.pipe(req);
-            return;
-        }
-
-        req.write(options.payload);
-    }
-
     // Custom abort method to detect early aborts
 
     const _abort = req.abort;
@@ -271,6 +247,29 @@ internals.Client.prototype.request = function (method, url, options, callback, _
         aborted = true;
         return _abort.call(req);
     };
+
+    // Write payload
+
+    if (payloadSupported) {
+        if (options.payload instanceof Stream) {
+            let stream = options.payload;
+
+            if (redirects) {
+                const collector = new Tap();
+                collector.once('finish', () => {
+
+                    shadow = collector.collect();
+                });
+
+                stream = options.payload.pipe(collector);
+            }
+
+            stream.pipe(req);
+            return req;
+        }
+
+        req.write(options.payload);
+    }
 
     // Finalize request
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "boom": "3.x.x",
-    "hoek": "3.x.x"
+    "hoek": "4.x.x"
   },
   "devDependencies": {
     "code": "2.x.x",

--- a/test/index.js
+++ b/test/index.js
@@ -1678,6 +1678,41 @@ describe('read()', () => {
             });
         });
     });
+
+    it('allows custom handling of response event and read works', (done) => {
+
+        const path = Path.join(__dirname, '../images/wreck.png');
+        const stats = Fs.statSync(path);
+        const fileStream = Fs.createReadStream(path);
+
+        const server = Http.createServer((req, res) => {
+
+            res.writeHead(200);
+            Wreck.read(req, null, (err, body) => {
+
+                expect(err).to.not.exist();
+                res.end(body);
+            });
+        });
+
+        server.listen(0, () => {
+
+            const req = Wreck.request('post', 'http://localhost:' + server.address().port, { payload: fileStream });
+
+            req.once('response', (res) => {
+
+                expect(res.statusCode).to.equal(200);
+
+                Wreck.read(res, null, (err, body) => {
+
+                    expect(err).to.not.exist();
+                    expect(body.length).to.equal(stats.size);
+                    server.close();
+                    done();
+                });
+            });
+        });
+    });
 });
 
 describe('parseCacheControl()', () => {


### PR DESCRIPTION
* Writing a payload still returns a client request object
* Omitting the callback on request no longer aborts the request