### PR TITLE
When getting 302 redirects while doing a POST, you would want the red…

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -283,7 +283,7 @@ internals.redirectMethod = function (code, method, options) {
     switch (code) {
         case 301:
         case 302:
-            return 'GET';
+            return method;
 
         case 303:
             if (options.redirect303) {


### PR DESCRIPTION
When getting 302 redirects while doing a POST, you would want the redirect from Wreck to use the same method and not GET.

For instance you POST to http://site/signin
You get a 302 redirect to location "https://site/signin". If Wreck changes the request to GET, this will fail.