### PR TITLE
Refactor event propagation

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -29,9 +29,6 @@ process[internals.emitSymbol] = process[internals.emitSymbol] || new Events.Even
 
 internals.Client = function (defaults) {
 
-    // Use a single emitter instance for events
-    Object.assign(this, process[internals.emitSymbol]);
-
     this.agents = {
         https: new Https.Agent({ maxSockets: Infinity }),
         http: new Http.Agent({ maxSockets: Infinity }),
@@ -39,6 +36,18 @@ internals.Client = function (defaults) {
     };
 
     this._defaults = defaults || {};
+
+    Events.EventEmitter.call(this);
+
+    // replay request/response events to process[Symbol.for('wreck')]
+    const self = this;
+    const selfEmit = this.emit;
+    this.emit = function () {
+
+        const processEmitter = process[internals.emitSymbol];
+        selfEmit.apply(self, arguments);
+        processEmitter.emit.apply(processEmitter, arguments);
+    };
 };
 
 Hoek.inherits(internals.Client, Events.EventEmitter);

--- a/test/index.js
+++ b/test/index.js
@@ -2386,6 +2386,38 @@ describe('Events', () => {
             });
         });
     });
+
+    it('clears once handlers from global emitter', (done) => {
+
+        const wreckEvents = process[Symbol.for('wreck')];
+        const server = Http.createServer((req, res) => {
+
+            res.writeHead(200);
+            res.end('ok');
+        });
+
+        let onceHandlerFired = false;
+        wreckEvents.once('request', () => {
+
+            onceHandlerFired = true;
+        });
+
+
+        server.listen(0, () => {
+
+            expect(wreckEvents.listeners('request').length).to.equal(1);
+            Wreck.get('http://localhost:' + server.address().port, (err, res, payload) => {
+
+                expect(err).to.not.exist();
+                expect(res.statusCode).to.equal(200);
+                expect(payload.toString()).to.equal('ok');
+                expect(onceHandlerFired).to.equal(true);
+                expect(wreckEvents.listeners('request').length).to.equal(0);
+                server.close();
+                done();
+            });
+        });
+    });
 });
 
 describe('Defaults', () => {


### PR DESCRIPTION
This PR refactors how events are propagated to `process[Symbol.for('wreck')]`. Instead of attempting to link the instances of Wreck and process emitter via `Object.assign`, which results in broken state, this PR keeps them separate and replays `emit`s from Wreck instances to the EventEmitter hanging off the process object. 

At the bottom of this description, I'm posting a sample that shows the broken state resulting from the current implementation.

This PR fixes #145 and joyent/node-consulite#3. 

Here's the simplest code I could think of to demonstrate the current disconnected state between process and Wreck emitters:

```javascript
'use strict'
const hoek = require('hoek')
const EventEmitter = require('events').EventEmitter

const emitter = new EventEmitter

function myEmitter () {
    Object.assign(this, emitter)
}

hoek.inherits(myEmitter, EventEmitter)

const emitterClone = new myEmitter()

emitterClone.on('request', requestHandler)
console.log('after add')
console.log('emitter handlers\n------------\n', emitter._events, '\n')
console.log('emitterClone handlers\n------------\n', emitterClone._events)

console.log('\n\n')

emitterClone.removeListener('request', requestHandler)
console.log('after remove')
console.log('emitter handlers\n------------\n', emitter._events, '\n')
console.log('emitterClone handlers\n------------\n', emitterClone._events)

function requestHandler () {}
```