### PR TITLE
Preserve `agents` across .defaults({...})

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,16 @@ const uri = '/';
 const readableStream = Wreck.toReadableStream('foo=bar');
 
 const wreck = Wreck.defaults({
-    headers: { 'x-foo-bar': 123 }
+    headers: { 'x-foo-bar': 123 },
+    agents: {
+        https: new Https.Agent({ maxSockets: 100 }),
+        http: new Http.Agent({ maxSockets: 1000 }),
+        httpsAllowUnauthorized: new Https.Agent({ maxSockets: 100, rejectUnauthorized: false })
+    }
 });
 
 // cascading example -- does not alter `wreck`
+// inherits `headers` and `agents` specified above
 const wreckWithTimeout = wreck.defaults({
     timeout: 5
 });
@@ -150,7 +156,7 @@ Convenience method for GET operations.
     - `err` - Any error that may have occurred during handling of the request or a Boom error object if the response has an error status code. If the error is a boom error object it will have the following properties in addition to the standard boom properties.
         - `data.isResponseError` - boolean, indicates if the error is a result of an error response status code
         - `data.headers` - object containing the response headers
-        - `data.payload` - the payload in the form of a Buffer or as a parsed object 
+        - `data.payload` - the payload in the form of a Buffer or as a parsed object
     - `response` - The [HTTP Incoming Message](https://nodejs.org/api/http.html#http_class_http_incomingmessage)
        object, which is a readable stream that has "ended" and contains no more data to read.
     - `payload` - The payload in the form of a Buffer or (optionally) parsed JavaScript object (JSON).

--- a/lib/index.js
+++ b/lib/index.js
@@ -18,7 +18,7 @@ const Tap = require('./tap');
 
 const internals = {
     jsonRegex: /^application\/[a-z.+-]*json$/,
-    shallowOptions: ['agent', 'payload', 'downstreamRes', 'beforeRedirect', 'redirected'],
+    shallowOptions: ['agents', 'agent', 'payload', 'downstreamRes', 'beforeRedirect', 'redirected'],
     emitSymbol: Symbol.for('wreck')
 };
 
@@ -29,13 +29,25 @@ process[internals.emitSymbol] = process[internals.emitSymbol] || new Events.Even
 
 internals.Client = function (defaults) {
 
-    this.agents = {
-        https: new Https.Agent({ maxSockets: Infinity }),
-        http: new Http.Agent({ maxSockets: Infinity }),
-        httpsAllowUnauthorized: new Https.Agent({ maxSockets: Infinity, rejectUnauthorized: false })
-    };
+    if (defaults) {
+        this._defaults = Hoek.cloneWithShallow(defaults, internals.shallowOptions);
+    }
 
-    this._defaults = defaults || {};
+    if (defaults  && defaults.agents) {
+        Hoek.assert(defaults.agents.https && defaults.agents.http && defaults.agents.httpsAllowUnauthorized,
+              'defaults.agents must include \'http\', \'https\' and \'httpsAllowUnauthorized\'');
+
+        this.agents = defaults.agents;
+    }
+    else {
+        this.agents = {
+            https: new Https.Agent({ maxSockets: Infinity }),
+            http: new Http.Agent({ maxSockets: Infinity }),
+            httpsAllowUnauthorized: new Https.Agent({ maxSockets: Infinity, rejectUnauthorized: false })
+        };
+
+        this._defaults = { agents: this.agents };
+    }
 
     Events.EventEmitter.call(this);
 
@@ -55,7 +67,10 @@ Hoek.inherits(internals.Client, Events.EventEmitter);
 
 internals.Client.prototype.defaults = function (options) {
 
-    options = Hoek.applyToDefaultsWithShallow(options, this._defaults, internals.shallowOptions);
+    Hoek.assert(typeof options === 'object',
+        'options must be provided to defaults');
+
+    options = Hoek.applyToDefaultsWithShallow(this._defaults, options, internals.shallowOptions);
     return new internals.Client(options);
 };
 
@@ -320,7 +335,7 @@ internals.redirectMethod = function (code, method, options) {
 
 internals.Client.prototype.read = function (res, options, callback) {
 
-    options = Hoek.applyToDefaultsWithShallow(options || {}, this._defaults, internals.shallowOptions);
+    options = Hoek.applyToDefaultsWithShallow(this._defaults, options || {}, internals.shallowOptions);
 
     // Set stream timeout
 


### PR DESCRIPTION
## problem
`const Wreck = require('wreck')` and `Wreck.defaults({})` instantiate their own agents rather than preserving the properties as you might expect when creating increasing granular http clients via `.defaults()`

## (my) use case

### declare application-level defaults via a hapijs plugin
```js
const MAX_FREE_SOCKETS = process.env.MAX_FREE_SOCKETS || 256;
const MAX_SOCKETS = process.env.MAX_SOCKETS || 128;
const KEEP_ALIVE = process.env.KEEP_ALIVE || true;
const KEEP_ALIVE_MSECS = process.env.KEEP_ALIVE_MSECS || 512;

exports.register = function (server, options, next) {

    function configureAgent(agent /* , type */) {
        agent.maxFreeSockets = MAX_FREE_SOCKETS;
        agent.maxSockets = MAX_SOCKETS;
        agent.keepAlive = KEEP_ALIVE;
        agent.keepAliveMsecs = KEEP_ALIVE_MSECS;
    }

    configureAgent(require('wreck').agents.http);
    configureAgent(require('wreck').agents.https);
    configureAgent(require('wreck').agents.httpsAllowUnauthorized);
    configureAgent(require('http').globalAgent);
    configureAgent(require('https').globalAgent);

    next();
  }

exports.register.attributes = {
    name: 'configure-http-agents',
    version: '1'
};
```

### create an http client pre-wired for our API
```js
function generateHerokuClient() {

    const proto = options.proto || HEROKU_API_PROTO;
    const host = options.host || HEROKU_API_HOST;
    const timeout = options.timeout || HTTP_TIMEOUT;
    const userAgent = options['user-agent'] || '';
    const variant = options.variant || 'application/vnd.heroku+json; version=3';
    const headers = {
        'accept': variant,
        'user-agent': `${pkg.name}/${pkg.version} ${userAgent}`.trim()
    };

    const heroku = Wreck.defaults({
        baseUrl: `${proto}//${host}/`,
        headers,
        timeout,
        json: true
    });

    return heorku;
}
```

### make succinct API calls
```js
heroku.get('/version', (err, version) => {
    reply(version);
});
```