### PR TITLE
Fix boom response error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Initiate an HTTP request.
       to force SSL version 3. The possible values depend on your installation of OpenSSL. Read the official OpenSSL docs
       for possible [SSL_METHODS](http://www.openssl.org/docs/ssl/ssl.html#DEALING_WITH_PROTOCOL_METHODS).
 - `callback` - The optional callback function using the signature `function (err, response)` where:
-    - `err` - Any error that may have occurred during the handling of the request or a Boom error object if the response has an error status code.
+    - `err` - Any error that may have occurred during the handling of the request.
     - `response` - The [HTTP Incoming Message](http://nodejs.org/api/http.html#http_http_incomingmessage)
        object, which is also a readable stream.
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -219,10 +219,6 @@ internals.Client.prototype.request = function (method, url, options, callback, _
             req.abort();
         }
 
-        if (!err && res.statusCode >= 400) {
-            err = Boom.create(res.statusCode, res.statusMessage);
-        }
-
         req.removeListener('response', onResponse);
         req.removeListener('error', onError);
         req.on('error', Hoek.ignore);
@@ -523,6 +519,10 @@ internals.Client.prototype._shortcut = function (method, uri, options, callback)
         }
 
         this.read(res, options, (err, payload) => {
+
+            if (!err && res.statusCode >= 400) {
+                return callback(Boom.create(res.statusCode));
+            }
 
             return callback(err, res, payload);
         });

--- a/lib/index.js
+++ b/lib/index.js
@@ -521,7 +521,11 @@ internals.Client.prototype._shortcut = function (method, uri, options, callback)
         this.read(res, options, (err, payload) => {
 
             if (!err && res.statusCode >= 400) {
-                return callback(Boom.create(res.statusCode));
+                return callback(Boom.create(res.statusCode, 'Response Error: ' + res.statusMessage, {
+                    isResponseError: true,
+                    headers: res.headers,
+                    payload
+                }));
             }
 
             return callback(err, res, payload);

--- a/test/index.js
+++ b/test/index.js
@@ -2053,16 +2053,21 @@ describe('Shortcut', () => {
 
         const server = Http.createServer((req, res) => {
 
+            res.setHeader('content-type', 'application/json');
+            res.setHeader('x-custom', 'yes');
             res.writeHead(400);
-            res.end();
+            res.end(JSON.stringify({ details: 'failed' }));
         });
 
         server.once('listening', () => {
 
-            Wreck.get('http://127.0.0.1:' + server.address().port, (err) => {
+            Wreck.get('http://127.0.0.1:' + server.address().port, { json: true }, (err) => {
 
                 expect(err.isBoom).to.be.true();
-                expect(err.message).to.equal('Bad Request');
+                expect(err.message).to.equal('Response Error: Bad Request');
+                expect(err.data.isResponseError).to.be.true();
+                expect(err.data.headers).to.include({ 'x-custom': 'yes' });
+                expect(err.data.payload).to.equal({ details: 'failed' });
                 done();
             });
         });

--- a/test/index.js
+++ b/test/index.js
@@ -1062,27 +1062,6 @@ describe('request()', () => {
         server.listen(0);
     });
 
-    it('handles error responses with a boom error object', (done) => {
-
-        const server = Http.createServer((req, res) => {
-
-            res.writeHead(400);
-            res.end();
-        });
-
-        server.once('listening', () => {
-
-            Wreck.request('get', 'http://127.0.0.1:' + server.address().port, { payload: '' }, (err) => {
-
-                expect(err.isBoom).to.be.true();
-                expect(err.message).to.equal('Bad Request');
-                done();
-            });
-        });
-
-        server.listen(0);
-    });
-
     it('handles request errors with a boom response when payload is being sent', (done) => {
 
         const server = Http.createServer((req, res) => {
@@ -1428,8 +1407,7 @@ describe('request()', () => {
 
             Wreck.request('post', 'http://localhost:' + server.address().port, { headers: { connection: 'close' }, payload: null }, (err, res) => {
 
-                expect(err).exist();
-                expect(err.isBoom).to.be.true();
+                expect(err).to.not.exist();
                 Wreck.read(res, null, (err, body) => {
 
                     expect(err).to.not.exist();
@@ -2070,6 +2048,28 @@ describe('Shortcut', () => {
             });
         });
     });
+
+    it('handles error responses with a boom error object', (done) => {
+
+        const server = Http.createServer((req, res) => {
+
+            res.writeHead(400);
+            res.end();
+        });
+
+        server.once('listening', () => {
+
+            Wreck.get('http://127.0.0.1:' + server.address().port, (err) => {
+
+                expect(err.isBoom).to.be.true();
+                expect(err.message).to.equal('Bad Request');
+                done();
+            });
+        });
+
+        server.listen(0);
+    });
+
 });
 
 describe('json', () => {


### PR DESCRIPTION
This fixes #82 without adding new options, while preserving most existing use-cases. This is done by only converting response errors to boom errors when the shortcut methods are used.

This also means that we can add payload information to the error, along with header information.

Finally, it ensures that clients can distinguish between response boom errors and native boom errors, which is impossible with the current implementation. If needed, this can be checked using the `err.data.isResponseError` property. Additionally, it is signalled as part of the message.

Note that this is a breaking change, and I have not updated the docs regarding the new `err.data` properties.