### PR TITLE
Include full response with the HTTP error

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,10 +153,11 @@ Convenience method for GET operations.
 - `options` - Optional config object containing settings for both `request` and
   `read` operations.
 - `callback` - The callback function using the signature `function (err, response, payload)` where:
-    - `err` - Any error that may have occurred during handling of the request or a Boom error object if the response has an error status code. If the error is a boom error object it will have the following properties in addition to the standard boom properties.
+    - `err` - Any error that may have occurred during handling of the request or a Boom error object if the response has an error status code (i.e. 4xx or 5xx). If the error is a boom error object it will have the following properties in addition to the standard boom properties.
         - `data.isResponseError` - boolean, indicates if the error is a result of an error response status code
         - `data.headers` - object containing the response headers
         - `data.payload` - the payload in the form of a Buffer or as a parsed object
+        - `data.response` - the [HTTP Incoming Message](https://nodejs.org/api/http.html#http_class_http_incomingmessage) object
     - `response` - The [HTTP Incoming Message](https://nodejs.org/api/http.html#http_class_http_incomingmessage)
        object, which is a readable stream that has "ended" and contains no more data to read.
     - `payload` - The payload in the form of a Buffer or (optionally) parsed JavaScript object (JSON).
@@ -171,10 +172,11 @@ Convenience method for POST operations.
 - `options` - Optional config object containing settings for both `request` and
   `read` operations.
 - `callback` - The callback function using the signature `function (err, response, payload)` where:
-    - `err` - Any error that may have occurred during handling of the request or a Boom error object if the response has an error status code. If the error is a boom error object it will have the following properties in addition to the standard boom properties.
+    - `err` - Any error that may have occurred during handling of the request or a Boom error object if the response has an error status code (i.e. 4xx or 5xx). If the error is a boom error object it will have the following properties in addition to the standard boom properties.
         - `data.isResponseError` - boolean, indicates if the error is a result of an error response status code
         - `data.headers` - object containing the response headers
         - `data.payload` - the payload in the form of a Buffer or as a parsed object
+        - `data.response` - the [HTTP Incoming Message](https://nodejs.org/api/http.html#http_class_http_incomingmessage) object
     - `response` - The [HTTP Incoming Message](https://nodejs.org/api/http.html#http_class_http_incomingmessage)
        object, which is a readable stream that has "ended" and contains no more data to read.
     - `payload` - The payload in the form of a Buffer or (optionally) parsed JavaScript object (JSON).
@@ -188,10 +190,11 @@ Convenience method for PATCH operations.
 - `options` - Optional config object containing settings for both `request` and
   `read` operations.
 - `callback` - The callback function using the signature `function (err, response, payload)` where:
-    - `err` - Any error that may have occurred during handling of the request or a Boom error object if the response has an error status code. If the error is a boom error object it will have the following properties in addition to the standard boom properties.
+    - `err` - Any error that may have occurred during handling of the request or a Boom error object if the response has an error status code (i.e. 4xx or 5xx). If the error is a boom error object it will have the following properties in addition to the standard boom properties.
         - `data.isResponseError` - boolean, indicates if the error is a result of an error response status code
         - `data.headers` - object containing the response headers
         - `data.payload` - the payload in the form of a Buffer or as a parsed object
+        - `data.response` - the [HTTP Incoming Message](https://nodejs.org/api/http.html#http_class_http_incomingmessage) object
     - `response` - The [HTTP Incoming Message](https://nodejs.org/api/http.html#http_class_http_incomingmessage)
        object, which is a readable stream that has "ended" and contains no more data to read.
     - `payload` - The payload in the form of a Buffer or (optionally) parsed JavaScript object (JSON).
@@ -206,10 +209,11 @@ Convenience method for PUT operations.
 - `options` - Optional config object containing settings for both `request` and
   `read` operations.
 - `callback` - The callback function using the signature `function (err, response, payload)` where:
-    - `err` - Any error that may have occurred during handling of the request or a Boom error object if the response has an error status code. If the error is a boom error object it will have the following properties in addition to the standard boom properties.
+    - `err` - Any error that may have occurred during handling of the request or a Boom error object if the response has an error status code (i.e. 4xx or 5xx). If the error is a boom error object it will have the following properties in addition to the standard boom properties.
         - `data.isResponseError` - boolean, indicates if the error is a result of an error response status code
         - `data.headers` - object containing the response headers
         - `data.payload` - the payload in the form of a Buffer or as a parsed object
+        - `data.response` - the [HTTP Incoming Message](https://nodejs.org/api/http.html#http_class_http_incomingmessage) object
     - `response` - The [HTTP Incoming Message](https://nodejs.org/api/http.html#http_class_http_incomingmessage)
        object, which is a readable stream that has "ended" and contains no more data to read.
     - `payload` - The payload in the form of a Buffer or (optionally) parsed JavaScript object (JSON).
@@ -224,10 +228,11 @@ Convenience method for DELETE operations.
 - `options` - Optional config object containing settings for both `request` and
   `read` operations.
 - `callback` - The callback function using the signature `function (err, response, payload)` where:
-    - `err` - Any error that may have occurred during handling of the request or a Boom error object if the response has an error status code. If the error is a boom error object it will have the following properties in addition to the standard boom properties.
+    - `err` - Any error that may have occurred during handling of the request or a Boom error object if the response has an error status code (i.e. 4xx or 5xx). If the error is a boom error object it will have the following properties in addition to the standard boom properties.
         - `data.isResponseError` - boolean, indicates if the error is a result of an error response status code
         - `data.headers` - object containing the response headers
         - `data.payload` - the payload in the form of a Buffer or as a parsed object
+        - `data.response` - the [HTTP Incoming Message](https://nodejs.org/api/http.html#http_class_http_incomingmessage) object
     - `response` - The [HTTP Incoming Message](https://nodejs.org/api/http.html#http_class_http_incomingmessage)
        object, which is a readable stream that has "ended" and contains no more data to read.
     - `payload` - The payload in the form of a Buffer or (optionally) parsed JavaScript object (JSON).

--- a/lib/index.js
+++ b/lib/index.js
@@ -530,6 +530,7 @@ internals.Client.prototype._shortcut = function (method, uri, options, callback)
                 return callback(Boom.create(res.statusCode, new Error(`Response Error: ${res.statusMessage}`), {
                     isResponseError: true,
                     headers: res.headers,
+                    response: res,
                     payload
                 }));
             }

--- a/lib/index.js
+++ b/lib/index.js
@@ -527,7 +527,7 @@ internals.Client.prototype._shortcut = function (method, uri, options, callback)
         this.read(res, options, (err, payload) => {
 
             if (!err && res.statusCode >= 400) {
-                return callback(Boom.create(res.statusCode, new Error(`Response Error: ${res.statusMessage}`), {
+                return callback(Boom.create(res.statusCode, new Error(`Response Error: ${res.statusCode} ${res.statusMessage}`), {
                     isResponseError: true,
                     headers: res.headers,
                     response: res,

--- a/test/index.js
+++ b/test/index.js
@@ -2064,7 +2064,7 @@ describe('Shortcut', () => {
             Wreck.get('http://127.0.0.1:' + server.address().port, { json: true }, (err) => {
 
                 expect(err.isBoom).to.be.true();
-                expect(err.message).to.equal('Response Error: Bad Request');
+                expect(err.message).to.equal('Response Error: 400 Bad Request');
                 expect(err.data.isResponseError).to.be.true();
                 expect(err.data.headers).to.include({ 'x-custom': 'yes' });
                 expect(err.data.payload).to.equal({ details: 'failed' });

--- a/test/index.js
+++ b/test/index.js
@@ -2068,6 +2068,7 @@ describe('Shortcut', () => {
                 expect(err.data.isResponseError).to.be.true();
                 expect(err.data.headers).to.include({ 'x-custom': 'yes' });
                 expect(err.data.payload).to.equal({ details: 'failed' });
+                expect(err.data.response.statusCode).to.equal(400);
                 done();
             });
         });


### PR DESCRIPTION
Closes #173.

I'm not sure if changing the error message is a breaking change - if so - it might be worth removing the `headers` while at it as it duplicates `response.headers`.