### PR TITLE
Return errors for partial payload transfers

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -382,6 +382,7 @@ internals.Client.prototype._read = function (res, options, callback) {
         reader.removeListener('error', onReaderError);
         reader.removeListener('finish', onReaderFinish);
         res.removeListener('error', onResError);
+        res.removeListener('close', onResAborted);
         res.removeListener('aborted', onResAborted);
         res.on('error', Hoek.ignore);
 
@@ -444,6 +445,7 @@ internals.Client.prototype._read = function (res, options, callback) {
     };
 
     res.once('error', onResError);
+    res.once('close', onResAborted);
     res.once('aborted', onResAborted);
 
     // Read payload

--- a/lib/index.js
+++ b/lib/index.js
@@ -382,7 +382,7 @@ internals.Client.prototype._read = function (res, options, callback) {
         reader.removeListener('error', onReaderError);
         reader.removeListener('finish', onReaderFinish);
         res.removeListener('error', onResError);
-        res.removeListener('close', onResClose);
+        res.removeListener('aborted', onResAborted);
         res.on('error', Hoek.ignore);
 
         if (err) {
@@ -438,13 +438,13 @@ internals.Client.prototype._read = function (res, options, callback) {
         return finishOnce(err.isBoom ? err : Boom.internal('Payload stream error', err));
     };
 
-    const onResClose = () => {
+    const onResAborted = () => {
 
         return finishOnce(Boom.internal('Payload stream closed prematurely'));
     };
 
     res.once('error', onResError);
-    res.once('close', onResClose);
+    res.once('aborted', onResAborted);
 
     // Read payload
 


### PR DESCRIPTION
I found that the `"handles responses that close early"` test doesn't do what it says. It merely tests, that if someone emits `close` on the response, it will react as if it is aborted.

Unfortunately, node uses `aborted` for this, ~~and `close` is never called~~.

I fixed the implementation to use the correct event, and replaced the test with proper ones. 