### PR TITLE
test(request) correct tests to check errors for boom instance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,5 +10,5 @@ Code changes are welcome and should follow the guidelines below.
 * Fork the repository on GitHub.
 * Fix the issue ensuring that your code follows the [style guide](https://github.com/hapijs/contrib/blob/master/Style.md).
 * Add tests for your new code ensuring that you have 100% code coverage (we can help you reach 100% but will not merge without it). 
-    * Run `make test-cov-html` to generate a report of test coverage
+    * Run `npm run test-cov-html` to generate a report of test coverage
 * [Pull requests](http://help.github.com/send-pull-requests/) should be made to the [master branch](https://github.com/hapijs/wreck/tree/master).

--- a/test/index.js
+++ b/test/index.js
@@ -593,7 +593,8 @@ describe('request()', () => {
         };
 
         const server = await internals.server(handler);
-        await expect(Wreck.request('get', 'http://127.0.0.1:' + server.address().port)).to.reject();
+        const err = await expect(Wreck.request('get', 'http://127.0.0.1:' + server.address().port)).to.reject();
+        expect(err.isBoom).to.equal(true);
     });
 
     it('handles request errors with a boom response when payload is being sent', async () => {
@@ -605,7 +606,8 @@ describe('request()', () => {
         };
 
         const server = await internals.server(handler);
-        await expect(Wreck.request('get', 'http://127.0.0.1:' + server.address().port, { payload: internals.payload })).to.reject();
+        const err = await expect(Wreck.request('get', 'http://127.0.0.1:' + server.address().port, { payload: internals.payload })).to.reject();
+        expect(err.isBoom).to.equal(true);
     });
 
     it('handles response errors with a boom response (res.destroy)', async () => {
@@ -616,7 +618,8 @@ describe('request()', () => {
         };
 
         const server = await internals.server(handler);
-        await expect(Wreck.request('get', 'http://127.0.0.1:' + server.address().port)).to.reject();
+        const err = await expect(Wreck.request('get', 'http://127.0.0.1:' + server.address().port)).to.reject();
+        expect(err.isBoom).to.equal(true);
     });
 
     it('handles errors when remote server is unavailable', async () => {


### PR DESCRIPTION
This PR corrects some tests that claim to test for errors being a boom instance but dont actually test it.