### PR TITLE
Handle stream payload errors before socket connection

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -336,10 +336,16 @@ internals.deferPipeUntilSocketConnects = function (req, stream) {
     };
     const onSocketConnect = () => {
 
+        stream.removeListener('error', onStreamError);
         stream.pipe(req);
+    };
+    const onStreamError = (err) => {
+
+        req.emit('error', err);
     };
 
     req.on('socket', onSocket);
+    stream.on('error', onStreamError);
 };
 
 

--- a/test/index.js
+++ b/test/index.js
@@ -1127,17 +1127,11 @@ describe('read()', () => {
         const stream = new Stream.Readable({
             read() {
 
-                piped = true;
+                read = true;
                 this.push(null);
             }
         });
-        const onPiped = () => {
-
-            piped = true;
-        };
-        let piped = false;
-
-        stream.on('pipe', onPiped);
+        let read = false;
 
         const promiseA = Wreck.request('post', 'http://localhost:0', {
             agent,
@@ -1145,7 +1139,7 @@ describe('read()', () => {
         });
 
         await expect(promiseA).to.reject(Error, /Unable to obtain socket/);
-        expect(piped).to.equal(false);
+        expect(read).to.equal(false);
 
         const handler = (req, res) => {
 
@@ -1158,7 +1152,7 @@ describe('read()', () => {
             payload: stream
         });
         expect(res.statusCode).to.equal(200);
-        expect(piped).to.equal(true);
+        expect(read).to.equal(true);
         server.close();
     });
 

--- a/test/index.js
+++ b/test/index.js
@@ -1162,6 +1162,23 @@ describe('read()', () => {
         server.close();
     });
 
+    it('will handle stream payload errors between request creation and connection establishment', async () => {
+
+        const agent = new internals.SlowAgent();
+        const stream = new Stream.Readable();
+        const promiseA = Wreck.request('post', 'http://localhost:0', {
+            agent,
+            payload: stream
+        });
+
+        process.nextTick(() => {
+
+            stream.emit('error', new Error('Asynchronous stream error'));
+        });
+
+        await expect(promiseA).to.reject(Error, /Asynchronous stream error/);
+    });
+
     it('times out when stream read takes too long', async () => {
 
         const TestStream = function () {


### PR DESCRIPTION
#223 introduced a small window between the creation of the request and the socket connection wherein `error` events on the payload would have no attached handler and could cause uncaught exceptions.

This PR includes a regression test as well as the fix:

- Attach a temporary error handler to the `options.payload` whose piping has been deferred
- When such error events happen, re-emit the error on the `req` itself and allow this to clean itself up

Open questions:

- [ ] should we remove the `socket` listener in `onStreamError`?
- [ ] should we even be using `req.emit('error', err)` as the mechanism to propagate the error?
- [ ] will things be correctly cleaned up for errors so-emitted?