### PR TITLE
Handle edge cases introduced with deferred payload piping

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -332,11 +332,15 @@ internals.deferPipeUntilSocketConnects = function (req, stream) {
 
     const onSocket = (socket) => {
 
+        if (!socket.connecting) {
+
+            return onSocketConnect();
+        }
+
         socket.once('connect', onSocketConnect);
     };
     const onSocketConnect = () => {
 
-        stream.removeListener('error', onStreamError);
         stream.pipe(req);
         stream.removeListener('error', onStreamError);
     };
@@ -344,11 +348,6 @@ internals.deferPipeUntilSocketConnects = function (req, stream) {
 
         req.emit('error', err);
     };
-    const onStreamError = (err) => {
-
-        req.emit('error', err);
-    };
-
 
     req.once('socket', onSocket);
     stream.on('error', onStreamError);

--- a/lib/index.js
+++ b/lib/index.js
@@ -338,6 +338,11 @@ internals.deferPipeUntilSocketConnects = function (req, stream) {
 
         stream.removeListener('error', onStreamError);
         stream.pipe(req);
+        stream.removeListener('error', onStreamError);
+    };
+    const onStreamError = (err) => {
+
+        req.emit('error', err);
     };
     const onStreamError = (err) => {
 


### PR DESCRIPTION
- If an error was emitted on the payload stream before the socket is connected, this could cause an uncaught exception
- If a socket is re-used (for example from a keep-alive `Agent`), it may already be connected and therefore not emit `connect`. This only waits for the `connect` event if the socket is in the `.connecting` state.