### PR TITLE
Whatwg url

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -169,9 +169,9 @@ internals.Client.prototype._request = function (method, url, options, relay, _tr
     _trace = (_trace || []);
     _trace.push({ method: uri.method, url });
 
-    const client = (parsedUri.protocol === 'https:' ? Https : Http);
+    const client = (uri.protocol === 'https:' ? Https : Http);
 
-    if (options.rejectUnauthorized !== undefined && parsedUri.protocol === 'https:') {
+    if (options.rejectUnauthorized !== undefined && uri.protocol === 'https:') {
         uri.agent = options.rejectUnauthorized ? this.agents.https : this.agents.httpsAllowUnauthorized;
     }
     else if (options.agent || options.agent === false) {
@@ -676,6 +676,10 @@ internals.applyUrlToOptions = (options, url) => {
     options.href = url.href;
     if (url.port !== '') {
         options.port = Number(url.port);
+    }
+
+    if (url.username || url.password) {
+        options.auth = `${url.username}:${url.password}`;
     }
 
     return options;

--- a/lib/index.js
+++ b/lib/index.js
@@ -178,7 +178,7 @@ internals.Client.prototype._request = function (method, url, options, relay, _tr
         uri.agent = options.agent;
     }
     else {
-        uri.agent = parsedUri.protocol === 'https:' ? this.agents.https : this.agents.http;
+        uri.agent = uri.protocol === 'https:' ? this.agents.https : this.agents.http;
     }
 
     if (options.secureProtocol !== undefined) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -190,14 +190,7 @@ internals.Client.prototype._request = function (method, url, options, relay, _tr
     }
 
     if (this._emit) {
-        const payload = uri;
-        payload.origin = parsedUri.origin;
-        payload.username = parsedUri.username;
-        payload.password = parsedUri.password;
-        payload.host = parsedUri.host;
-        payload.searchParams = parsedUri.searchParams;
-
-        this._emit('request', payload, options);
+        this._emit('request', uri, options);
     }
 
     const start = Date.now();
@@ -667,6 +660,8 @@ internals.findHeader = function (headerName, headers) {
 
 internals.applyUrlToOptions = (options, url) => {
 
+    options.origin = url.origin;
+    options.searchParams = url.searchParams;
     options.protocol = url.protocol;
     options.hostname = url.hostname;
     options.hash = url.hash;
@@ -680,6 +675,8 @@ internals.applyUrlToOptions = (options, url) => {
 
     if (url.username || url.password) {
         options.auth = `${url.username}:${url.password}`;
+        options.username = url.username;
+        options.password = url.password;
     }
 
     return options;

--- a/lib/index.js
+++ b/lib/index.js
@@ -123,84 +123,85 @@ internals.Client.prototype.request = function (method, url, options = {}) {
 
 internals.Client.prototype._request = function (method, url, options, relay, _trace) {
 
-    const requestOptions = {};
-    let uri;
+    const uri = {};
+    let parsedUri;
     if (options.socketPath) {
-        requestOptions.socketPath = options.socketPath;
+        uri.socketPath = options.socketPath;
         delete options.socketPath;
-        uri = Url.parse(url);
+        parsedUri = Url.parse(url);
     }
     else {
-        requestOptions.setHost = false;
-        uri = new Url.URL(url);
+        uri.setHost = false;
+        parsedUri = new Url.URL(url);
     }
-    internals.applyUrlToOptions(requestOptions, uri);
 
-    requestOptions.method = method.toUpperCase();
-    requestOptions.headers = options.headers || {};
-    requestOptions.headers.host = uri.host;
-    const hasContentLength = internals.findHeader('content-length', requestOptions.headers) !== undefined;
+    internals.applyUrlToOptions(uri, parsedUri);
+
+    uri.method = method.toUpperCase();
+    uri.headers = options.headers || {};
+    uri.headers.host = parsedUri.host;
+    const hasContentLength = internals.findHeader('content-length', uri.headers) !== undefined;
 
     if (options.payload && typeof options.payload === 'object' && !(options.payload instanceof Stream) && !Buffer.isBuffer(options.payload)) {
         options.payload = JSON.stringify(options.payload);
-        if (!internals.findHeader('content-type', requestOptions.headers)) {
-            requestOptions.headers['content-type'] = 'application/json';
+        if (!internals.findHeader('content-type', uri.headers)) {
+            uri.headers['content-type'] = 'application/json';
         }
     }
 
     if (options.gunzip &&
-        internals.findHeader('accept-encoding', requestOptions.headers) === undefined) {
+        internals.findHeader('accept-encoding', uri.headers) === undefined) {
 
-            requestOptions.headers['accept-encoding'] = 'gzip';
+        uri.headers['accept-encoding'] = 'gzip';
     }
 
-    const payloadSupported = (requestOptions.method !== 'GET' && requestOptions.method !== 'HEAD' && options.payload !== null && options.payload !== undefined);
+    const payloadSupported = (uri.method !== 'GET' && uri.method !== 'HEAD' && options.payload !== null && options.payload !== undefined);
     if (payloadSupported &&
         (typeof options.payload === 'string' || Buffer.isBuffer(options.payload)) &&
         (!hasContentLength)) {
 
-            requestOptions.headers = Hoek.clone(requestOptions.headers);
-            requestOptions.headers['content-length'] = Buffer.isBuffer(options.payload) ? options.payload.length : Buffer.byteLength(options.payload);
+        uri.headers = Hoek.clone(uri.headers);
+        uri.headers['content-length'] = Buffer.isBuffer(options.payload) ? options.payload.length : Buffer.byteLength(options.payload);
     }
 
     let redirects = (options.hasOwnProperty('redirects') ? options.redirects : false);      // Needed to allow 0 as valid value when passed recursively
 
     _trace = (_trace || []);
-    _trace.push({ method: requestOptions.method, url });
+    _trace.push({ method: uri.method, url });
 
-    const client = (uri.protocol === 'https:' ? Https : Http);
+    const client = (parsedUri.protocol === 'https:' ? Https : Http);
 
-    if (options.rejectUnauthorized !== undefined && uri.protocol === 'https:') {
-        requestOptions.agent = options.rejectUnauthorized ? this.agents.https : this.agents.httpsAllowUnauthorized;
+    if (options.rejectUnauthorized !== undefined && parsedUri.protocol === 'https:') {
+        uri.agent = options.rejectUnauthorized ? this.agents.https : this.agents.httpsAllowUnauthorized;
     }
     else if (options.agent || options.agent === false) {
-        requestOptions.agent = options.agent;
+        uri.agent = options.agent;
     }
     else {
-        requestOptions.agent = uri.protocol === 'https:' ? this.agents.https : this.agents.http;
+        uri.agent = parsedUri.protocol === 'https:' ? this.agents.https : this.agents.http;
     }
 
     if (options.secureProtocol !== undefined) {
-        requestOptions.secureProtocol = options.secureProtocol;
+        uri.secureProtocol = options.secureProtocol;
     }
 
     if (options.ciphers !== undefined) {
-        requestOptions.ciphers = options.ciphers;
+        uri.ciphers = options.ciphers;
     }
 
     if (this._emit) {
-        const payload = requestOptions;
-        payload.origin = uri.origin;
-        payload.username = uri.username;
-        payload.password = uri.password;
-        payload.host = uri.host;
-        payload.searchParams = uri.searchParams;
+        const payload = uri;
+        payload.origin = parsedUri.origin;
+        payload.username = parsedUri.username;
+        payload.password = parsedUri.password;
+        payload.host = parsedUri.host;
+        payload.searchParams = parsedUri.searchParams;
 
         this._emit('request', payload, options);
     }
 
     const start = Date.now();
-    const req = client.request(requestOptions);
+    const req = client.request(uri);
 
     let shadow = null;                                                                      // A copy of the streamed request payload when redirects are enabled
     let timeoutId;
@@ -218,7 +219,7 @@ internals.Client.prototype._request = function (method, url, options, relay, _tr
         // Pass-through response
 
         const statusCode = res.statusCode;
-        const redirectMethod = internals.redirectMethod(statusCode, requestOptions.method, options);
+        const redirectMethod = internals.redirectMethod(statusCode, uri.method, options);
 
         if (redirects === false ||
             !redirectMethod) {
@@ -665,20 +666,16 @@ internals.findHeader = function (headerName, headers) {
 };
 
 internals.applyUrlToOptions = (options, url) => {
+
     options.protocol = url.protocol;
-    options.hostname = typeof url.hostname === 'string' && url.hostname.startsWith('[') ?
-          url.hostname.slice(1, -1) :
-          url.hostname;
+    options.hostname = url.hostname;
     options.hash = url.hash;
     options.search = url.search;
     options.pathname = url.pathname;
-    options.path = `${url.pathname || ''}${url.search || ''}`;
+    options.path = `${url.pathname}${url.search || ''}`;
     options.href = url.href;
     if (url.port !== '') {
         options.port = Number(url.port);
-    }
-    if (url.username || url.password) {
-        options.auth = `${url.username}:${url.password}`;
     }
 
     return options;

--- a/lib/index.js
+++ b/lib/index.js
@@ -123,70 +123,84 @@ internals.Client.prototype.request = function (method, url, options = {}) {
 
 internals.Client.prototype._request = function (method, url, options, relay, _trace) {
 
-    const uri = Url.parse(url);
-
+    const requestOptions = {};
+    let uri;
     if (options.socketPath) {
-        uri.socketPath = options.socketPath;
+        requestOptions.socketPath = options.socketPath;
         delete options.socketPath;
+        uri = Url.parse(url);
     }
+    else {
+        requestOptions.setHost = false;
+        uri = new Url.URL(url);
+    }
+    internals.applyUrlToOptions(requestOptions, uri);
 
-    uri.method = method.toUpperCase();
-    uri.headers = options.headers || {};
-    const hasContentLength = internals.findHeader('content-length', uri.headers) !== undefined;
+    requestOptions.method = method.toUpperCase();
+    requestOptions.headers = options.headers || {};
+    requestOptions.headers.host = uri.host;
+    const hasContentLength = internals.findHeader('content-length', requestOptions.headers) !== undefined;
 
     if (options.payload && typeof options.payload === 'object' && !(options.payload instanceof Stream) && !Buffer.isBuffer(options.payload)) {
         options.payload = JSON.stringify(options.payload);
-        if (!internals.findHeader('content-type', uri.headers)) {
-            uri.headers['content-type'] = 'application/json';
+        if (!internals.findHeader('content-type', requestOptions.headers)) {
+            requestOptions.headers['content-type'] = 'application/json';
         }
     }
 
     if (options.gunzip &&
-        internals.findHeader('accept-encoding', uri.headers) === undefined) {
+        internals.findHeader('accept-encoding', requestOptions.headers) === undefined) {
 
-        uri.headers['accept-encoding'] = 'gzip';
+            requestOptions.headers['accept-encoding'] = 'gzip';
     }
 
-    const payloadSupported = (uri.method !== 'GET' && uri.method !== 'HEAD' && options.payload !== null && options.payload !== undefined);
+    const payloadSupported = (requestOptions.method !== 'GET' && requestOptions.method !== 'HEAD' && options.payload !== null && options.payload !== undefined);
     if (payloadSupported &&
         (typeof options.payload === 'string' || Buffer.isBuffer(options.payload)) &&
         (!hasContentLength)) {
 
-        uri.headers = Hoek.clone(uri.headers);
-        uri.headers['content-length'] = Buffer.isBuffer(options.payload) ? options.payload.length : Buffer.byteLength(options.payload);
+            requestOptions.headers = Hoek.clone(requestOptions.headers);
+            requestOptions.headers['content-length'] = Buffer.isBuffer(options.payload) ? options.payload.length : Buffer.byteLength(options.payload);
     }
 
     let redirects = (options.hasOwnProperty('redirects') ? options.redirects : false);      // Needed to allow 0 as valid value when passed recursively
 
     _trace = (_trace || []);
-    _trace.push({ method: uri.method, url });
+    _trace.push({ method: requestOptions.method, url });
 
     const client = (uri.protocol === 'https:' ? Https : Http);
 
     if (options.rejectUnauthorized !== undefined && uri.protocol === 'https:') {
-        uri.agent = options.rejectUnauthorized ? this.agents.https : this.agents.httpsAllowUnauthorized;
+        requestOptions.agent = options.rejectUnauthorized ? this.agents.https : this.agents.httpsAllowUnauthorized;
     }
     else if (options.agent || options.agent === false) {
-        uri.agent = options.agent;
+        requestOptions.agent = options.agent;
     }
     else {
-        uri.agent = uri.protocol === 'https:' ? this.agents.https : this.agents.http;
+        requestOptions.agent = uri.protocol === 'https:' ? this.agents.https : this.agents.http;
     }
 
     if (options.secureProtocol !== undefined) {
-        uri.secureProtocol = options.secureProtocol;
+        requestOptions.secureProtocol = options.secureProtocol;
     }
 
     if (options.ciphers !== undefined) {
-        uri.ciphers = options.ciphers;
+        requestOptions.ciphers = options.ciphers;
     }
 
     if (this._emit) {
-        this._emit('request', uri, options);
+        const payload = requestOptions;
+        payload.origin = uri.origin;
+        payload.username = uri.username;
+        payload.password = uri.password;
+        payload.host = uri.host;
+        payload.searchParams = uri.searchParams;
+
+        this._emit('request', payload, options);
     }
 
     const start = Date.now();
-    const req = client.request(uri);
+    const req = client.request(requestOptions);
 
     let shadow = null;                                                                      // A copy of the streamed request payload when redirects are enabled
     let timeoutId;
@@ -204,7 +218,7 @@ internals.Client.prototype._request = function (method, url, options, relay, _tr
         // Pass-through response
 
         const statusCode = res.statusCode;
-        const redirectMethod = internals.redirectMethod(statusCode, uri.method, options);
+        const redirectMethod = internals.redirectMethod(statusCode, requestOptions.method, options);
 
         if (redirects === false ||
             !redirectMethod) {
@@ -648,6 +662,26 @@ internals.findHeader = function (headerName, headers) {
         .find((key) => key.toLowerCase() === headerName.toLowerCase());
 
     return foundKey && headers[foundKey];
+};
+
+internals.applyUrlToOptions = (options, url) => {
+    options.protocol = url.protocol;
+    options.hostname = typeof url.hostname === 'string' && url.hostname.startsWith('[') ?
+          url.hostname.slice(1, -1) :
+          url.hostname;
+    options.hash = url.hash;
+    options.search = url.search;
+    options.pathname = url.pathname;
+    options.path = `${url.pathname || ''}${url.search || ''}`;
+    options.href = url.href;
+    if (url.port !== '') {
+        options.port = Number(url.port);
+    }
+    if (url.username || url.password) {
+        options.auth = `${url.username}:${url.password}`;
+    }
+
+    return options;
 };
 
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "scripts": {
     "lint-md": "eslint --config hapi --parser-options=ecmaVersion:8 --rule 'strict: 0, eol-last: 0' --plugin markdown --ext md .",
     "posttest": "npm run lint-md",
-    "test": "lab -a code",
+    "test": "lab -t 100 -L -a code",
     "test-cov-html": "lab -r html -o coverage.html -a code"
   },
   "license": "BSD-3-Clause"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "scripts": {
     "lint-md": "eslint --config hapi --parser-options=ecmaVersion:8 --rule 'strict: 0, eol-last: 0' --plugin markdown --ext md .",
     "posttest": "npm run lint-md",
-    "test": "lab -t 100 -L -a code",
+    "test": "lab -a code",
     "test-cov-html": "lab -r html -o coverage.html -a code"
   },
   "license": "BSD-3-Clause"

--- a/test/index.js
+++ b/test/index.js
@@ -437,6 +437,13 @@ describe('request()', () => {
         server.close();
     });
 
+    it('handles uri with WHATWG parsing', async() => {
+
+        const promise = Wreck.request('get', 'http://localhost%60malicious.org',);
+        await expect(promise).to.reject();
+        expect(promise.req._headers.host).to.equal('localhost`malicious.org');
+    });
+
     it('reaches max redirections count', async () => {
 
         let gen = 0;
@@ -889,12 +896,29 @@ describe('request()', () => {
         Wreck.agents.http.maxSockets = Infinity;
     });
 
+    /*
+    {
+     protocol: null,
+     slashes: null,
+     auth: null,
+     host: null,
+     port: null,
+     hostname: null,
+     hash: null,
+     search: null,
+     query: null,
+     pathname: '/',
+     path: '/',
+     href: '/',
+     socketPath: '/Users/wtyler/Code/OSS/wreck/test/server.sock',
+     method: 'POST',
+    */
     describe('unix socket', () => {
 
         it('requests a resource', async () => {
 
             const server = await internals.server(null, internals.socket);
-            const res = await Wreck.request('get', '/', { socketPath: internals.socket });
+            const res = await Wreck.request('get', '/', { agent: false, socketPath: internals.socket });
             const body = await Wreck.read(res);
             expect(Buffer.isBuffer(body)).to.equal(true);
             expect(body.toString()).to.equal(internals.payload);

--- a/test/index.js
+++ b/test/index.js
@@ -419,7 +419,12 @@ describe('request()', () => {
             redirected: (statusCode, location, req) => {
 
                 expect(location).to.equal('https://hapijs.com');
-                expect(req.output[0]).to.include('hapijs.com');
+                if (req.output) {
+                    expect(req.output[0]).to.include('hapijs.com');
+                }
+                else {
+                    expect(req.outputData[0].data).to.include('hapijs.com');
+                }
             }
         };
 

--- a/test/index.js
+++ b/test/index.js
@@ -437,7 +437,7 @@ describe('request()', () => {
         server.close();
     });
 
-    it('handles uri with WHATWG parsing', async() => {
+    it('handles uri with WHATWG parsing', async () => {
 
         const promise = Wreck.request('get', 'http://localhost%60malicious.org',);
         await expect(promise).to.reject();
@@ -896,29 +896,12 @@ describe('request()', () => {
         Wreck.agents.http.maxSockets = Infinity;
     });
 
-    /*
-    {
-     protocol: null,
-     slashes: null,
-     auth: null,
-     host: null,
-     port: null,
-     hostname: null,
-     hash: null,
-     search: null,
-     query: null,
-     pathname: '/',
-     path: '/',
-     href: '/',
-     socketPath: '/Users/wtyler/Code/OSS/wreck/test/server.sock',
-     method: 'POST',
-    */
     describe('unix socket', () => {
 
         it('requests a resource', async () => {
 
             const server = await internals.server(null, internals.socket);
-            const res = await Wreck.request('get', '/', { agent: false, socketPath: internals.socket });
+            const res = await Wreck.request('get', '/', { socketPath: internals.socket });
             const body = await Wreck.read(res);
             expect(Buffer.isBuffer(body)).to.equal(true);
             expect(body.toString()).to.equal(internals.payload);


### PR DESCRIPTION
Per #238 - this updates Wreck to leverage the WHATWG Url parser rather than the old Url.parse.

There are some breaking changes in how hosts and URIs are parsed between the two methods, especially when it comes to host headers containing the port and also to Unix socket connections. I wanted to keep this as a non-breaking update in Wreck, so there are some maybe-weird conditionals to handle parsing the uri using the old Url.parse for Unix sockets as well as some weird property mapping.

With regards to the last point (`internals.applyUrlToOptions`), this is due to the getters on the Symbol properties on the new Url.URL class. Just as a point of interest, this is the exact same strategy that Node.js itself is using internally in making a request instance [here](https://github.com/nodejs/node/blob/master/lib/internal/url.js#L1254-L1276).

I'm assuming this is going to be a first pass, so please let me know what changes and simplifications you'd like to see. :) 