### PR TITLE
Explicit host header trumps host implied in url

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -129,7 +129,13 @@ internals.Client.prototype._request = function (method, url, options, relay, _tr
 
     uri.method = method.toUpperCase();
     uri.headers = options.headers || {};
-    uri.headers.host = uri.host;
+
+    const hostHeader = internals.findHeader('host', uri.headers);
+
+    if (!hostHeader) {
+        uri.headers.host = uri.host;
+    }
+
     const hasContentLength = internals.findHeader('content-length', uri.headers) !== undefined;
 
     if (options.payload && typeof options.payload === 'object' && !(options.payload instanceof Stream) && !Buffer.isBuffer(options.payload)) {

--- a/test/index.js
+++ b/test/index.js
@@ -1000,6 +1000,20 @@ describe('options.baseUrl', () => {
         expect(promise.req._headers.host).to.equal('localhost:8080');
     });
 
+    it('uses lower-case host header when path is not a full URL', async () => {
+
+        const promise = Wreck.request('get', '/foo', { baseUrl: 'http://localhost:0/', headers: { Host: 'localhost:8080' } });
+        await expect(promise).to.reject();
+        expect(promise.req._headers.host).to.equal('localhost:8080');
+    });
+
+    it('uses upper-case host header when path is not a full URL', async () => {
+
+        const promise = Wreck.request('get', '/foo', { baseUrl: 'http://localhost:0/', headers: { Host: 'localhost:8080' } });
+        await expect(promise).to.reject();
+        expect(promise.req._headers.host).to.equal('localhost:8080');
+    });
+
     it('uses baseUrl option with trailing slash and uri is prefixed with a slash', async () => {
 
         const promise = Wreck.request('get', '/foo', { baseUrl: 'http://localhost:0/' });
@@ -2013,19 +2027,19 @@ describe('Defaults', () => {
         const wreckB = Wreck.defaults(optionsB);
         const wreckAB = wreckA.defaults(optionsB);
 
-        const promise1 = wreckA.request('get', 'http://no_such_host_error/', { headers: { banana: 911 } });
+        const promise1 = wreckA.request('get', 'http://127.0.0.1:0/', { headers: { banana: 911 } });
         await expect(promise1).to.reject();
         expect(promise1.req._headers.banana).to.exist();
         expect(promise1.req._headers.foo).to.exist();
         expect(promise1.req._headers.bar).to.not.exist();
 
-        const promise2 = wreckB.request('get', 'http://no_such_host_error/', { headers: { banana: 911 } });
+        const promise2 = wreckB.request('get', 'http://127.0.0.1:0/', { headers: { banana: 911 } });
         await expect(promise2).to.reject();
         expect(promise2.req._headers.banana).to.exist();
         expect(promise2.req._headers.foo).to.not.exist();
         expect(promise2.req._headers.bar).to.exist();
 
-        const promise3 = wreckAB.request('get', 'http://no_such_host_error/', { headers: { banana: 911 } });
+        const promise3 = wreckAB.request('get', 'http://127.0.0.1:0/', { headers: { banana: 911 } });
         await expect(promise3).to.reject();
         expect(promise3.req._headers.banana).to.exist();
         expect(promise3.req._headers.foo).to.exist();
@@ -2039,7 +2053,7 @@ describe('Defaults', () => {
 
         const wreckA = Wreck.defaults(optionsA);
 
-        const promise1 = wreckA.request('get', 'http://no_such_host_error/', optionsB);
+        const promise1 = wreckA.request('get', 'http://127.0.0.1:0/', optionsB);
         await expect(promise1).to.reject();
         expect(promise1.req._headers.accept).to.equal('bar');
         expect(promise1.req._headers.test).to.equal(123);

--- a/test/index.js
+++ b/test/index.js
@@ -1002,7 +1002,7 @@ describe('options.baseUrl', () => {
 
     it('uses lower-case host header when path is not a full URL', async () => {
 
-        const promise = Wreck.request('get', '/foo', { baseUrl: 'http://localhost:0/', headers: { Host: 'localhost:8080' } });
+        const promise = Wreck.request('get', '/foo', { baseUrl: 'http://localhost:0/', headers: { host: 'localhost:8080' } });
         await expect(promise).to.reject();
         expect(promise.req._headers.host).to.equal('localhost:8080');
     });


### PR DESCRIPTION
Fixes #245.