### PR TITLE
Return an empty buffer payload on text content-type rather than `null`

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -430,10 +430,6 @@ internals.Client.prototype._read = function (res, options, callback) {
 
         // Parse JSON
 
-        if (buffer.length === 0) {
-            return callback(null, null);
-        }
-
         if (options.json === 'force') {
             return internals.tryParseBuffer(buffer, callback);
         }
@@ -637,6 +633,10 @@ internals.Client.prototype._shortcut = async function (method, uri, options = {}
 
 
 internals.tryParseBuffer = function (buffer, next) {
+
+    if (buffer.length === 0) {
+        return next(null, null);
+    }
 
     let payload;
     try {

--- a/test/index.js
+++ b/test/index.js
@@ -1601,7 +1601,7 @@ describe('json', () => {
         server.close();
     });
 
-    it('should not be parsed on empty buffer', async () => {
+    it('should not be parsed on empty buffer (json: SMART)', async () => {
 
         const handler = (req, res) => {
 
@@ -1611,6 +1611,58 @@ describe('json', () => {
 
         const server = await internals.server(handler);
         const options = { json: 'SMART' };
+
+        const { res, payload } = await Wreck.get('http://localhost:' + server.address().port, options);
+        expect(res.statusCode).to.equal(204);
+        expect(payload).to.equal(null);
+        server.close();
+    });
+
+    it('should not be parsed on empty buffer (json: force)', async () => {
+
+        const handler = (req, res) => {
+
+            res.writeHead(204, { 'Content-Type': 'application/json' });
+            res.end();
+        };
+
+        const server = await internals.server(handler);
+        const options = { json: 'force' };
+
+        const { res, payload } = await Wreck.get('http://localhost:' + server.address().port, options);
+        expect(res.statusCode).to.equal(204);
+        expect(payload).to.equal(null);
+        server.close();
+    });
+
+    it('should return the empty buffer on text content-type (json: true)', async () => {
+
+        const handler = (req, res) => {
+
+            res.writeHead(204, { 'Content-Type': 'text/plain' });
+            res.end();
+        };
+
+        const server = await internals.server(handler);
+        const options = { json: true };
+
+        const { res, payload } = await Wreck.get('http://localhost:' + server.address().port, options);
+        expect(res.statusCode).to.equal(204);
+        expect(Buffer.isBuffer(payload)).to.equal(true);
+        expect(payload.toString()).to.equal('');
+        server.close();
+    });
+
+    it('should return null on empty buffer with text content-type (json: force)', async () => {
+
+        const handler = (req, res) => {
+
+            res.writeHead(204, { 'Content-Type': 'text/plain' });
+            res.end();
+        };
+
+        const server = await internals.server(handler);
+        const options = { json: 'force' };
 
         const { res, payload } = await Wreck.get('http://localhost:' + server.address().port, options);
         expect(res.statusCode).to.equal(204);


### PR DESCRIPTION
Closes #220.

Technically this is a breaking change for those who expect the `null` for `content-type: text/*`.