### PR TITLE
Respect uri parameter when using socketPath

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Initiate an HTTP request.
     - `baseUrl` - fully qualified uri string used as the base url. Most useful with `request.defaults`, for example when you want to do many requests to the same domain.
                   If `baseUrl` is `https://example.com/api/`, then requesting `/end/point?test=true` will fetch `https://example.com/end/point?test=true`. Any
                   querystring in the `baseUrl` will be overwritten with the querystring in the `uri` When `baseUrl` is given, `uri` must also be a string. In order to retain the `/api/` portion of the `baseUrl` in the example, the `path` must not start with a leading `/` and the `baseUrl` must end with a trailing `/`.
-    - `socketPath` - `/path/to/unix/socket` for Server. When using `socketPath` the `uri` parameter to `request` and the shortcut functions will be ignored.
+    - `socketPath` - `/path/to/unix/socket` for Server.
     - `payload` - The request body as a string, Buffer, Readable Stream, or an object that can be serialized using `JSON.stringify()`.
     - `headers` - An object containing request headers.
     - `redirects` - The maximum number of redirects to follow.

--- a/lib/index.js
+++ b/lib/index.js
@@ -118,8 +118,18 @@ internals.Client.prototype._request = function (method, url, options, relay, _tr
     const uri = {};
     if (options.socketPath) {
         uri.socketPath = options.socketPath;
-        // The host must be empty according to https://tools.ietf.org/html/rfc2616#section-14.23
-        uri.host = '';
+
+        const parsedUri = new Url.URL(url, `unix://${options.socketPath}`);
+        internals.applyUrlToOptions(uri, {
+            // The host must be empty according to https://tools.ietf.org/html/rfc2616#section-14.23
+            host: '',
+            protocol: 'http:',
+            hash: parsedUri.hash,
+            search: parsedUri.search,
+            searchParams: parsedUri.searchParams,
+            pathname: parsedUri.pathname,
+            href: parsedUri.href
+        });
     }
     else {
         uri.setHost = false;

--- a/test/index.js
+++ b/test/index.js
@@ -929,6 +929,14 @@ describe('request()', () => {
             server.close();
         });
 
+        it('requests a resource at a subpath', async () => {
+
+            const server = await internals.server(null, internals.socket);
+            const res = await Wreck.request('get', '/subpath', { socketPath: internals.socket });
+            expect(res.req.path).to.equal('/subpath');
+            server.close();
+        });
+
         it('requests a POST resource', async () => {
 
             const server = await internals.server('echo', internals.socket);


### PR DESCRIPTION
As stated in the README since version 15, 'when using `socketPath` the `uri` parameter to `request` and the shortcut functions will be ignored'.

This means that one can no longer request anything but '/' from an HTTP server that is listening on a Unix socket. Could you comment on why this change was made? 

My proposal to restore the functionality from wreck v14 is to use the URL constructor with a pseudo-base url and to only use those of the resulting options that were previously also set by `url.parse()`.

Usage example (essentially same as with v14):
```js
const Wreck = require('@hapi/wreck');

const makeRequest = async () => {

    const docker = Wreck.defaults({ socketPath: '/var/run/docker.sock' });
    const { payload } = await docker.get('/v1.37/containers/json', { json: true });
    console.log(payload);
};

makeRequest();
```