### PR TITLE
Don't set redirected host header

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -115,7 +115,7 @@ internals.Client = class {
         }
 
         uri.method = method.toUpperCase();
-        uri.headers = options.headers || {};
+        uri.headers = Object.assign({}, options.headers);
 
         const hostHeader = internals.findHeader('host', uri.headers);
 
@@ -143,7 +143,6 @@ internals.Client = class {
             (typeof options.payload === 'string' || Buffer.isBuffer(options.payload)) &&
             !hasContentLength) {
 
-            uri.headers = Hoek.clone(uri.headers);
             uri.headers['content-length'] = Buffer.isBuffer(options.payload) ? options.payload.length : Buffer.byteLength(options.payload);
         }
 
@@ -642,10 +641,13 @@ internals.tryParseBuffer = function (buffer, next) {
 
 internals.findHeader = function (headerName, headers) {
 
-    const foundKey = Object.keys(headers)
-        .find((key) => key.toLowerCase() === headerName.toLowerCase());
+    const normalizedName = headerName.toLowerCase();
 
-    return foundKey && headers[foundKey];
+    for (const key of Object.keys(headers)) {
+        if (key.toLowerCase() === normalizedName) {
+            return headers[key];
+        }
+    }
 };
 
 

--- a/test/index.js
+++ b/test/index.js
@@ -2298,7 +2298,7 @@ internals.server = function (handler, socket) {
 
             return req.headers.host === 'localhost:' + server.address().port ||
                    req.headers.host === '127.0.0.1:' + server.address().port;
-        }
+        };
 
         if (!socket && !isValidHost()) {
 


### PR DESCRIPTION
This fixes a rather critical regression, where the redirect fails to work when:

1. The redirected location points to a new host.
1. The call to wreck contains a `headers` object in the options.
1. The remote server uses virtual hosting based on the `host` header.

I suspect this bug was introduced with e663215e9ae9ecf91eb6158fc23ad35f8dd21e21 aimed to fix _ #246.

I fixed it by never modifying the headers passed to the original request. Additionally, I added logic to all test handlers to do a vhost lookup.

For reference, the following currently fails:
```js
await Wreck.get('http://google.com/', { redirects: 3, headers: {} });
```

Result:
```
Error: Maximum redirections reached
    at ClientRequest.onResponse (.../node_modules/@hapi/wreck/lib/index.js:218:40)
    at Object.onceWrapper (events.js:300:26)
    at ClientRequest.emit (events.js:210:5)
    at ClientRequest.EventEmitter.emit (domain.js:499:23)
    at HTTPParser.parserOnIncomingClient [as onIncoming] (_http_client.js:583:27)
    at HTTPParser.parserOnHeadersComplete (_http_common.js:115:17)
    at Socket.socketOnData (_http_client.js:456:22)
    at Socket.emit (events.js:210:5)
    at Socket.EventEmitter.emit (domain.js:499:23)
    at addChunk (_stream_readable.js:308:12) {
  data: [
    { method: 'GET', url: 'http://google.com/' },
    { method: 'GET', url: 'http://www.google.com/' },
    { method: 'GET', url: 'http://www.google.com/' },
    { method: 'GET', url: 'http://www.google.com/' }
  ],
  isBoom: true,
  isServer: true,
  output: {
    statusCode: 502,
    payload: {
      statusCode: 502,
      error: 'Bad Gateway',
      message: 'Maximum redirections reached'
    },
    headers: {}
  }
}
```