### PR TITLE
Refactor early abort detection to use the 'abort' event

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -192,6 +192,17 @@ internals.Client = class {
             return finishOnce(Boom.badGateway('Client request error', err));
         };
 
+        const onAbort = () => {
+
+            if (!req.socket) {
+                // Fake an ECONNRESET error on early abort
+
+                const error = new Error('socket hang up');
+                error.code = 'ECONNRESET';
+                finishOnce(error);
+            }
+        };
+
         req.once('error', onError);
 
         const onResponse = (res) => {
@@ -251,9 +262,9 @@ internals.Client = class {
                 req.abort();
             }
 
-            req.abort = _abort;                             // Restore original function to release memory
             req.removeListener('response', onResponse);
             req.removeListener('error', onError);
+            req.removeListener('abort', onAbort);
             req.on('error', Hoek.ignore);
 
             clearTimeout(timeoutId);
@@ -272,26 +283,7 @@ internals.Client = class {
             delete options.timeout;
         }
 
-        // Custom abort method to detect early aborts
-
-        const _abort = req.abort;
-        let aborted = false;
-        req.abort = () => {
-
-            if (!aborted && !req.res && !req.socket) {
-                process.nextTick(() => {
-
-                    // Fake an ECONNRESET error
-
-                    const error = new Error('socket hang up');
-                    error.code = 'ECONNRESET';
-                    finishOnce(error);
-                });
-            }
-
-            aborted = true;
-            return _abort.call(req);
-        };
+        req.on('abort', onAbort);
 
         // Write payload
 


### PR DESCRIPTION
The hack was only required on older node versions.