### PR TITLE
Cancel redirect request

### DIFF
--- a/API.md
+++ b/API.md
@@ -102,7 +102,7 @@ Initiate an HTTP request.
           - `location` - The redirect location string.
           - `resHeaders` - An object with the headers received as part of the redirection response.
           - `redirectOptions` - Options that will be applied to the redirect request. Changes to this object are applied to the redirection request.
-          - `next` - the callback function called to perform the redirection using signature `function()`.
+          - `next` - the callback function called to perform the redirection using signature `function(err)`. Passing an error into callback will stop the redirect request.
           
     - `ciphers` - [TLS](https://nodejs.org/api/tls.html#tls_modifying_the_default_tls_cipher_suite) list of TLS ciphers to override node's default. The possible values depend on your installation of OpenSSL. Read the official OpenSSL docs for possible [TLS_CIPHERS](https://www.openssl.org/docs/man1.0.2/apps/ciphers.html#CIPHER-LIST-FORMAT).
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -244,8 +244,10 @@ internals.Client = class {
             }
 
             const followRedirect = (err) => {
+            
                 if (err) {
-                    return finishOnce(Boom.badGateway('Invalid redirect: ' + err.message, _trace));
+                    err.trace = _trace;
+                    return finishOnce(Boom.badGateway('Invalid redirect', err));
                 }
 
                 const redirectReq = this._request(redirectMethod, location, redirectOptions, { callback: finishOnce }, _trace);

--- a/lib/index.js
+++ b/lib/index.js
@@ -243,7 +243,10 @@ internals.Client = class {
                 redirectOptions.timeout = (redirectOptions.timeout - elapsed).toString();           // stringify to not drop timeout when === 0
             }
 
-            const followRedirect = () => {
+            const followRedirect = (err) => {
+                if (err) {
+                    return finishOnce(Boom.badGateway('Invalid redirect: ' + err.message, _trace));
+                }
 
                 const redirectReq = this._request(redirectMethod, location, redirectOptions, { callback: finishOnce }, _trace);
                 if (options.redirected) {

--- a/test/index.js
+++ b/test/index.js
@@ -618,6 +618,28 @@ describe('request()', () => {
         server.close();
     });
 
+    it('cancels redirect if beforeRedirect callback is called with an error', async () => {
+
+        const handler = (req, res) => {
+
+            req.destroy();
+            res.end();
+        };
+
+        const server = await internals.server(handler);
+
+        const err = new Error('Cancel');
+        const beforeRedirectCallback = function (redirectMethod, statusCode, location, headers, redirectOptions, next) {
+
+            return next(err);
+        };
+
+        const thrown = await expect(Wreck.request('get', 'http://localhost:' + server.address().port, { redirects: 5, beforeRedirect: beforeRedirectCallback })).to.reject();
+        expect(thrown.isBoom).to.equal(true);
+        expect(thrown.message).to.equal('Invalid redirect: ' + err.message);
+        server.close();
+    });
+
     it('calls redirected option callback on redirections', async () => {
 
         let gen = 0;


### PR DESCRIPTION
It would be nice to cancel a redirect, if e.g. the redirect url is malformed or leads to a suspicious location. This PR stops the redirect request if callback `next(err)` is called with an error.