### PR TITLE
strip authorization and cookie headers when redirecting to a new hostname

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -243,6 +243,19 @@ internals.Client = class {
                 redirectOptions.timeout = (redirectOptions.timeout - elapsed).toString();           // stringify to not drop timeout when === 0
             }
 
+            // When redirecting to a new hostname, remove the authorization and cookie headers
+            if (redirectOptions.headers) {
+                const parsedLocation = new URL(location);
+                if (uri.hostname !== parsedLocation.hostname) {
+                    for (const header of Object.keys(redirectOptions.headers)) {
+                        const lowerHeader = header.toLowerCase();
+                        if (lowerHeader === 'authorization' || lowerHeader === 'cookie') {
+                            delete redirectOptions.headers[header];
+                        }
+                    }
+                }
+            }
+
             const followRedirect = () => {
 
                 const redirectReq = this._request(redirectMethod, location, redirectOptions, { callback: finishOnce }, _trace);


### PR DESCRIPTION
the implementation of this fix follows suit with curl, request, node-fetch, undici, minipass-fetch, and make-fetch-happen

if the `hostname` property of the target url in a redirect differs from the original request's `hostname`, then we remove the `authorization` and `cookie` headers before following the redirect on the users behalf.