### PR TITLE
Repair test suite for node v16 autoDestroy and coverage change

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,5 +1,5 @@
-Copyright (c) 2012-2020, Sideway Inc, and project contributors  
-Copyright (c) 2012-2014, Walmart.  
+Copyright (c) 2012-2022, Sideway Inc, and project contributors
+Copyright (c) 2012-2014, Walmart.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/lib/index.js
+++ b/lib/index.js
@@ -57,9 +57,9 @@ internals.Client = class {
             options = Hoek.applyToDefaults(this._defaults, options, { shallow: internals.shallowOptions });
 
             Hoek.assert(options.payload === undefined || typeof options.payload === 'string' || typeof options.payload === 'object', 'options.payload must be a string, a Buffer, a Stream, or an Object');
-            Hoek.assert(options.agent === undefined || options.agent === null || typeof options.rejectUnauthorized !== 'boolean', 'options.agent cannot be set to an Agent at the same time as options.rejectUnauthorized is set');
-            Hoek.assert(options.beforeRedirect === undefined || options.beforeRedirect === null || typeof options.beforeRedirect === 'function', 'options.beforeRedirect must be a function');
-            Hoek.assert(options.redirected === undefined || options.redirected === null || typeof options.redirected === 'function', 'options.redirected must be a function');
+            Hoek.assert([null, undefined].includes(options.agent) || typeof options.rejectUnauthorized !== 'boolean', 'options.agent cannot be set to an Agent at the same time as options.rejectUnauthorized is set');
+            Hoek.assert([null, undefined].includes(options.beforeRedirect) || typeof options.beforeRedirect === 'function', 'options.beforeRedirect must be a function');
+            Hoek.assert([null, undefined].includes(options.redirected) || typeof options.redirected === 'function', 'options.redirected must be a function');
             Hoek.assert(options.gunzip === undefined || typeof options.gunzip === 'boolean' || options.gunzip === 'force', 'options.gunzip must be a boolean or "force"');
         }
         catch (err) {
@@ -138,7 +138,7 @@ internals.Client = class {
             uri.headers['accept-encoding'] = 'gzip';
         }
 
-        const payloadSupported = uri.method !== 'GET' && uri.method !== 'HEAD' && options.payload !== null && options.payload !== undefined;
+        const payloadSupported = uri.method !== 'GET' && uri.method !== 'HEAD' && ![null, undefined].includes(options.payload);
         if (payloadSupported &&
             (typeof options.payload === 'string' || Buffer.isBuffer(options.payload)) &&
             !hasContentLength) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -57,9 +57,9 @@ internals.Client = class {
             options = Hoek.applyToDefaults(this._defaults, options, { shallow: internals.shallowOptions });
 
             Hoek.assert(options.payload === undefined || typeof options.payload === 'string' || typeof options.payload === 'object', 'options.payload must be a string, a Buffer, a Stream, or an Object');
-            Hoek.assert([null, undefined].includes(options.agent) || typeof options.rejectUnauthorized !== 'boolean', 'options.agent cannot be set to an Agent at the same time as options.rejectUnauthorized is set');
-            Hoek.assert([null, undefined].includes(options.beforeRedirect) || typeof options.beforeRedirect === 'function', 'options.beforeRedirect must be a function');
-            Hoek.assert([null, undefined].includes(options.redirected) || typeof options.redirected === 'function', 'options.redirected must be a function');
+            Hoek.assert(internals.isNullOrUndefined(options.agent) || typeof options.rejectUnauthorized !== 'boolean', 'options.agent cannot be set to an Agent at the same time as options.rejectUnauthorized is set');
+            Hoek.assert(internals.isNullOrUndefined(options.beforeRedirect) || typeof options.beforeRedirect === 'function', 'options.beforeRedirect must be a function');
+            Hoek.assert(internals.isNullOrUndefined(options.redirected) || typeof options.redirected === 'function', 'options.redirected must be a function');
             Hoek.assert(options.gunzip === undefined || typeof options.gunzip === 'boolean' || options.gunzip === 'force', 'options.gunzip must be a boolean or "force"');
         }
         catch (err) {
@@ -138,7 +138,7 @@ internals.Client = class {
             uri.headers['accept-encoding'] = 'gzip';
         }
 
-        const payloadSupported = uri.method !== 'GET' && uri.method !== 'HEAD' && ![null, undefined].includes(options.payload);
+        const payloadSupported = uri.method !== 'GET' && uri.method !== 'HEAD' && !internals.isNullOrUndefined(options.payload);
         if (payloadSupported &&
             (typeof options.payload === 'string' || Buffer.isBuffer(options.payload)) &&
             !hasContentLength) {
@@ -672,5 +672,6 @@ internals.applyUrlToOptions = (options, url) => {
     return options;
 };
 
+internals.isNullOrUndefined = (val) => [null, undefined].includes(val);
 
 module.exports = new internals.Client();

--- a/test/index.js
+++ b/test/index.js
@@ -20,7 +20,7 @@ const internals = {
     gzippedPayload: Zlib.gzipSync(new Array(1640).join('0123456789')),
     socket: __dirname + '/server.sock',
     emitSymbol: Symbol.for('wreck'),
-    refusePort: process.env.ImageOS === 'win19' ? 777 : 0
+    refusePort: ['win19', 'win22'].includes(process.env.ImageOS) ? 777 : 0
 };
 
 

--- a/test/index.js
+++ b/test/index.js
@@ -560,17 +560,17 @@ describe('request()', () => {
             }, timeout);
 
             redirectCount++;
-            timeout = 10;
+            timeout = 20;
         };
 
         const server = await internals.server(handler);
-        const err = await expect(Wreck.request('get', 'http://localhost:' + server.address().port, { redirects: 5, timeout: 20 })).to.reject();
+        const err = await expect(Wreck.request('get', 'http://localhost:' + server.address().port, { redirects: 5, timeout: 40 })).to.reject();
         expect(err.output.statusCode).to.equal(504);
 
         // Validate that no further requests are made
 
         const targetCount = redirectCount;
-        await Hoek.wait(15);
+        await Hoek.wait(30);
         expect(redirectCount).to.equal(targetCount);
 
         server.close();
@@ -1492,6 +1492,7 @@ describe('read()', () => {
         const res = await Wreck.request('get', 'http://localhost:' + server.address().port);
 
         res.destroy = null;
+        res._readableState.autoDestroy = false; // As of node v16 autoDestroy is on, causing node to attempt to call destroy()
         const err = await expect(Wreck.read(res, { maxBytes: 120 })).to.reject();
         expect(err.output.statusCode).to.equal(413);
         server.close();


### PR DESCRIPTION
The test suite needed a little love.  Here are the changes:
 - As of node v16 `autoDestroy` is on streams.  This broke a test where we try to emulate a stream without a `destroy()` method.  See https://github.com/nodejs/node/issues/30625.
 - There were some coverage changes causing boolean expression branches to become stricter.  Anyone know where that came from?  I changed the code to remove the branches, each roughly of the form `x === undefined || x === null` to `[null, undefined].includes(x)`.
 - I came across one timing-dependent flaky test and just made it run longer to make it less likely to flake out on e.g. a busy event loop.
 - Make test suite aware of win22 in addition to win19.