### PR TITLE
Support node v18 and drop node v12

### DIFF
--- a/.github/workflows/ci-module.yml
+++ b/.github/workflows/ci-module.yml
@@ -10,3 +10,5 @@ on:
 jobs:
   test:
     uses: hapijs/.github/.github/workflows/ci-module.yml@master
+    with:
+      min-node-version: 14

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,5 @@
-Copyright (c) 2012-2022, Sideway Inc, and project contributors
+Copyright (c) 2012-2022, Project contributors
+Copyright (c) 2012-2020, Sideway Inc
 Copyright (c) 2012-2014, Walmart.
 All rights reserved.
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -148,7 +148,7 @@ internals.Client = class {
 
         let redirects = options.hasOwnProperty('redirects') ? options.redirects : false;        // Needed to allow 0 as valid value when passed recursively
 
-        _trace = _trace || [];
+        _trace = _trace ?? [];
         _trace.push({ method: uri.method, url });
 
         const client = uri.protocol === 'https:' ? Https : Http;
@@ -235,7 +235,7 @@ internals.Client = class {
             }
 
             const redirectOptions = Hoek.clone(options, { shallow: internals.shallowOptions });
-            redirectOptions.payload = shadow || options.payload;                                    // shadow must be ready at this point if set
+            redirectOptions.payload = shadow ?? options.payload;                                    // shadow must be ready at this point if set
             redirectOptions.redirects = --redirects;
             if (timeoutId) {
                 clearTimeout(timeoutId);
@@ -548,7 +548,7 @@ internals.Client = class {
             payload = await this.read(res, options);
         }
         catch (err) {
-            err.data = err.data || {};
+            err.data = err.data ?? {};
             err.data.res = res;
             throw err;
         }
@@ -675,7 +675,7 @@ internals.applyUrlToOptions = (options, url) => {
     options.hash = url.hash;
     options.search = url.search;
     options.pathname = url.pathname;
-    options.path = `${url.pathname}${url.search || ''}`;
+    options.path = `${url.pathname}${url.search}`;
     options.href = url.href;
     if (url.port !== '') {
         options.port = Number(url.port);

--- a/package.json
+++ b/package.json
@@ -14,14 +14,15 @@
         "lib"
     ],
     "dependencies": {
-        "@hapi/bourne": "2.x.x",
-        "@hapi/boom": "9.x.x",
-        "@hapi/hoek": "9.x.x"
+        "@hapi/boom": "^10.0.0",
+        "@hapi/bourne": "^3.0.0",
+        "@hapi/hoek": "^10.0.0"
     },
     "devDependencies": {
-        "@hapi/code": "8.x.x",
-        "@hapi/lab": "24.x.x",
-        "typescript": "~4.0.2"
+        "@hapi/code": "^9.0.0",
+        "@hapi/lab": "^25.0.0",
+        "@types/node": "^17.0.31",
+        "typescript": "~4.6.4"
     },
     "scripts": {
         "test": "lab -t 100 -L -a @hapi/code -m 10000 -Y",

--- a/test/index.ts
+++ b/test/index.ts
@@ -17,7 +17,7 @@ const server = Http.createServer((req, res) => {
     res.end('Some payload');
 });
 
-await new Promise((resolve) => server.listen(0, resolve));
+await new Promise((resolve) => server.listen(0, () => resolve(null)));
 const address = server.address() as Net.AddressInfo;
 const url = `http://localhost:${address.port}`;
 


### PR DESCRIPTION
 - Test on node v14+ and adopt some new syntax.
 - Update to node v18-compatible versions of hapi modules, update typescript.

If this looks good, this will go out as wreck v18.