### PR TITLE
add deflate parsing support

### DIFF
--- a/API.md
+++ b/API.md
@@ -142,6 +142,11 @@ Returns a promise that resolves into a node response object. The promise has a `
         - `false` - explicitly disable gunzipping.
         - `force` - try to gunzip regardless of the content-encoding header.
 
+    - `inflate` - determines how to handle zlib compressed payloads. Defaults to `false`.
+        - `true` - only try to inflate if the response indicates a deflate content-encoding.
+        - `false` - explicitly disable inflate.
+        - `force` - try to inflate regardless of the content-encoding header.
+
     - `json` - determines how to parse the payload as JSON:
         - `false` - leaves payload raw. This is the default value.
         - `true` - only try `JSON.parse` if the response indicates a JSON content-type.

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -233,6 +233,13 @@ declare namespace Client {
             readonly gunzip?: boolean | 'force';
 
             /**
+             * Determines how to handle zlib compressed payloads.
+             * 
+             * @default false
+             */
+            readonly inflate?: boolean | 'force';
+
+            /**
              * The request body as a string, Buffer, readable stream, or an object that can be serialized using `JSON.stringify()`.
              */
             readonly payload?: Payload;
@@ -307,6 +314,13 @@ declare namespace Client {
             * @default false
             */
             readonly gunzip?: boolean | 'force';
+
+            /**
+            * Determines how to handle zlib compressed payloads.
+            *
+            * @default false
+            */
+            readonly inflate?: boolean | 'force';
 
             /**
              * Determines how to parse the payload as JSON.

--- a/lib/index.js
+++ b/lib/index.js
@@ -61,6 +61,7 @@ internals.Client = class {
             Hoek.assert(internals.isNullOrUndefined(options.beforeRedirect) || typeof options.beforeRedirect === 'function', 'options.beforeRedirect must be a function');
             Hoek.assert(internals.isNullOrUndefined(options.redirected) || typeof options.redirected === 'function', 'options.redirected must be a function');
             Hoek.assert(options.gunzip === undefined || typeof options.gunzip === 'boolean' || options.gunzip === 'force', 'options.gunzip must be a boolean or "force"');
+            Hoek.assert(options.inflate === undefined || typeof options.inflate === 'boolean' || options.inflate === 'force', 'options.inflate must be a boolean or "force"');
         }
         catch (err) {
             return Promise.reject(err);
@@ -136,6 +137,12 @@ internals.Client = class {
             internals.findHeader('accept-encoding', uri.headers) === undefined) {
 
             uri.headers['accept-encoding'] = 'gzip';
+        }
+
+        if (options.inflate &&
+            internals.findHeader('accept-encoding', uri.headers) === undefined) {
+
+            uri.headers['accept-encoding'] = 'deflate';
         }
 
         const payloadSupported = uri.method !== 'GET' && uri.method !== 'HEAD' && !internals.isNullOrUndefined(options.payload);
@@ -465,6 +472,19 @@ internals.Client = class {
                 const gunzip = Zlib.createGunzip();
                 gunzip.once('error', onReaderError);
                 res.pipe(gunzip).pipe(reader);
+                return;
+            }
+        }
+
+        if (options.inflate) {
+            const contentEncoding = options.inflate === 'force' ?
+                'deflate' :
+                res.headers && internals.findHeader('content-encoding', res.headers) || '';
+
+            if (/^(x-)?deflate(\s*,\s*identity)?$/.test(contentEncoding)) {
+                const inflate = Zlib.createInflate();
+                inflate.once('error', onReaderError);
+                res.pipe(inflate).pipe(reader);
                 return;
             }
         }


### PR DESCRIPTION
inflate/deflate is supported by Hapi, along with `gzip` https://github.com/hapijs/hapi/blob/dc2213c880f16ff6853eccc684782ec888326475/lib/compression.js#L17. But is not listed in the parsing options for `Wreck.read`.

This PR adds the option `inflate` in the same way that `gunzip` is written.