### PR TITLE
Fix test failing on new node versions

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -2112,6 +2112,7 @@ describe('gunzip', () => {
 
             const err = await expect(Wreck.get(`http://localhost:${server.address().port}`, options)).to.reject();
             expect(err).to.be.an.error(/Unexpected token/);
+            expect(Boom.isBoom(err)).to.be.true();
             expect(err.data.res.statusCode).to.equal(200);
             expect(err.data.payload).to.equal(Zlib.gzipSync(JSON.stringify({ foo: 'bar' })));
             flags.onCleanup = () => server.close();

--- a/test/index.js
+++ b/test/index.js
@@ -2111,7 +2111,7 @@ describe('gunzip', () => {
             const options = { json: true };
 
             const err = await expect(Wreck.get(`http://localhost:${server.address().port}`, options)).to.reject();
-            expect(err).to.be.an.error('Unexpected token \u001f in JSON at position 0');
+            expect(err).to.be.an.error(/Unexpected token/);
             expect(err.data.res.statusCode).to.equal(200);
             expect(err.data.payload).to.equal(Zlib.gzipSync(JSON.stringify({ foo: 'bar' })));
             flags.onCleanup = () => server.close();


### PR DESCRIPTION
There has been a subtle change in the error message for the `Unexpected token`  JSON parsing error.

Easiest fix is this one here that changes the test to simply test for the inclusion of the phrase `Unexpected token` rather than the exact wording of the error.

Found when I tried to help debug #305