### PR TITLE
support custom lookup function in request()

### DIFF
--- a/API.md
+++ b/API.md
@@ -148,6 +148,8 @@ Returns a promise that resolves into a node response object. The promise has a `
         - `'strict'` - as `true`, except returns an error for non-JSON content-type.
         - `'force'` - try `JSON.parse` regardless of the content-type header.
 
+    - `lookup` - DNS lookup function. see [http.request(url[,options][,callback])](https://nodejs.org/api/http.html#httprequestoptions-callback). Defaults to [dns.lookup()](https://nodejs.org/api/dns.html#dnslookuphostname-options-callback).
+
     - `maxBytes` - the maximum allowed response payload size. Defaults to `0` (no limit).
 
     - `timeout` - the number of milliseconds to wait while reading data before aborting handling of the response. Defaults to `0`.

--- a/API.md
+++ b/API.md
@@ -130,6 +130,13 @@ Initiate an HTTP request.
 
     - `timeout` - number of milliseconds to wait without receiving a response before aborting the request. Defaults to `0` (no limit).
 
+    - `lookup` - DNS lookup function. see [http.request(url[,options][,callback])](https://nodejs.org/api/http.html#httprequestoptions-callback). Defaults to [dns.lookup()](https://nodejs.org/api/dns.html#dnslookuphostname-options-callback).
+
+    - `family` - IP address family to use when resolving `host` or `hostname`. Valid values are `4` or `6`. When unspecified, both IP v4 and v6 will be used.
+
+    - `hints` - Optional `dns.lookup()` hints.
+
+
 Returns a promise that resolves into a node response object. The promise has a `req` property which is the instance of the node.js [ClientRequest](http://nodejs.org/api/http.html#http_class_http_clientrequest) object.
 
 ### `read(response, options)`
@@ -147,8 +154,6 @@ Returns a promise that resolves into a node response object. The promise has a `
         - `true` - only try `JSON.parse` if the response indicates a JSON content-type.
         - `'strict'` - as `true`, except returns an error for non-JSON content-type.
         - `'force'` - try `JSON.parse` regardless of the content-type header.
-
-    - `lookup` - DNS lookup function. see [http.request(url[,options][,callback])](https://nodejs.org/api/http.html#httprequestoptions-callback). Defaults to [dns.lookup()](https://nodejs.org/api/dns.html#dnslookuphostname-options-callback).
 
     - `maxBytes` - the maximum allowed response payload size. Defaults to `0` (no limit).
 

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -205,6 +205,16 @@ declare namespace Client {
             readonly lookup?: LookupFunction;
 
             /**
+             * IP address family to use when resolving host or hostname. Valid values are 4 or 6. When unspecified, both IP v4 and v6 will be used.
+             */
+            readonly family?: number;
+
+            /**
+             * Optional dns.lookup() hints.
+             */
+            readonly hints?: number;
+
+            /**
              * Fully qualified URL string used as the base URL.
              */
             readonly baseUrl?: string;

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -5,6 +5,7 @@ import * as Http from 'http';
 import * as Https from 'https';
 import * as Stream from 'stream';
 import * as Url from 'url';
+import { LookupFunction } from "node:net"
 
 import { Boom } from '@hapi/boom';
 
@@ -197,6 +198,11 @@ declare namespace Client {
              * Node HTTP or HTTPS Agent object (false disables agent pooling).
              */
             readonly agent?: Http.Agent | Https.Agent | false;
+
+            /**
+             * Custom lookup function. Default: dns.lookup().
+             */
+            readonly lookup?: LookupFunction;
 
             /**
              * Fully qualified URL string used as the base URL.

--- a/lib/index.js
+++ b/lib/index.js
@@ -18,7 +18,7 @@ const Tap = require('./tap');
 
 const internals = {
     jsonRegex: /^application\/([a-z0-9.]*[+-]json|json)$/,
-    shallowOptions: ['agent', 'agents', 'beforeRedirect', 'payload', 'redirected']
+    shallowOptions: ['agent', 'agents', 'beforeRedirect', 'payload', 'redirected', 'lookup']
 };
 
 
@@ -61,6 +61,7 @@ internals.Client = class {
             Hoek.assert(internals.isNullOrUndefined(options.beforeRedirect) || typeof options.beforeRedirect === 'function', 'options.beforeRedirect must be a function');
             Hoek.assert(internals.isNullOrUndefined(options.redirected) || typeof options.redirected === 'function', 'options.redirected must be a function');
             Hoek.assert(options.gunzip === undefined || typeof options.gunzip === 'boolean' || options.gunzip === 'force', 'options.gunzip must be a boolean or "force"');
+            Hoek.assert(options.lookup === undefined || typeof options.lookup === 'function', 'options.lookup must be a function');
         }
         catch (err) {
             return Promise.reject(err);
@@ -152,6 +153,10 @@ internals.Client = class {
         _trace.push({ method: uri.method, url });
 
         const client = uri.protocol === 'https:' ? Https : Http;
+
+        if (options.lookup !== undefined) {
+            uri.lookup = options.lookup;
+        }
 
         if (options.rejectUnauthorized !== undefined &&
             uri.protocol === 'https:') {

--- a/lib/index.js
+++ b/lib/index.js
@@ -18,7 +18,8 @@ const Tap = require('./tap');
 
 const internals = {
     jsonRegex: /^application\/([a-z0-9.]*[+-]json|json)$/,
-    shallowOptions: ['agent', 'agents', 'beforeRedirect', 'payload', 'redirected', 'lookup']
+    shallowOptions: ['agent', 'agents', 'beforeRedirect', 'payload', 'redirected'],
+    httpOptions: ['secureProtocol', 'ciphers', 'lookup', 'family', 'hints']
 };
 
 
@@ -61,7 +62,6 @@ internals.Client = class {
             Hoek.assert(internals.isNullOrUndefined(options.beforeRedirect) || typeof options.beforeRedirect === 'function', 'options.beforeRedirect must be a function');
             Hoek.assert(internals.isNullOrUndefined(options.redirected) || typeof options.redirected === 'function', 'options.redirected must be a function');
             Hoek.assert(options.gunzip === undefined || typeof options.gunzip === 'boolean' || options.gunzip === 'force', 'options.gunzip must be a boolean or "force"');
-            Hoek.assert(options.lookup === undefined || typeof options.lookup === 'function', 'options.lookup must be a function');
         }
         catch (err) {
             return Promise.reject(err);
@@ -154,8 +154,10 @@ internals.Client = class {
 
         const client = uri.protocol === 'https:' ? Https : Http;
 
-        if (options.lookup !== undefined) {
-            uri.lookup = options.lookup;
+        for (const option of internals.httpOptions) {
+            if (options[option] !== undefined) {
+                uri[option] = options[option];
+            }
         }
 
         if (options.rejectUnauthorized !== undefined &&
@@ -170,14 +172,6 @@ internals.Client = class {
         }
         else {
             uri.agent = uri.protocol === 'https:' ? this.agents.https : this.agents.http;
-        }
-
-        if (options.secureProtocol !== undefined) {
-            uri.secureProtocol = options.secureProtocol;
-        }
-
-        if (options.ciphers !== undefined) {
-            uri.ciphers = options.ciphers;
         }
 
         this._emit('preRequest', uri, options);

--- a/test/index.js
+++ b/test/index.js
@@ -1196,6 +1196,29 @@ describe('request()', () => {
     });
 });
 
+describe('options.lookup', () => {
+
+    it('uses the lookup function to resolve the server ip address', async (flags) => {
+
+        const server = await internals.server('ok');
+        const promise = Wreck.request('get', `http://localhost:${server.address().port}/`, {
+            lookup: (_hostname, _options, callback) => callback(null, [{ address: '127.0.0.1', family: 4 }])
+        });
+        await expect(promise).to.not.reject();
+        flags.onCleanup = () => server.close();
+    });
+
+    it('uses the lookup function and fails if the lookup function rejects the domain', async (flags) => {
+
+        const server = await internals.server('ok');
+        const promise = Wreck.request('get', `http://localhost:${server.address().port}/`, {
+            lookup: (_hostname, _options, callback) => callback(new Error('failed lookup'))
+        });
+        await expect(promise).to.reject('Client request error: failed lookup');
+        flags.onCleanup = () => server.close();
+    });
+});
+
 describe('options.baseUrl', () => {
 
     it('uses path when path is a full URL', async (flags) => {

--- a/test/index.js
+++ b/test/index.js
@@ -1202,7 +1202,15 @@ describe('options.lookup', () => {
 
         const server = await internals.server('ok');
         const promise = Wreck.request('get', `http://localhost:${server.address().port}/`, {
-            lookup: (_hostname, _options, callback) => callback(null, [{ address: '127.0.0.1', family: 4 }])
+            lookup: (_hostname, options, callback) => {
+
+                if (options.all) {
+                    callback(null, [{ address: '127.0.0.1', family: 4 }]);
+                    return;
+                }
+
+                callback(null, '127.0.0.1', 4);
+            }
         });
         await expect(promise).to.not.reject();
         flags.onCleanup = () => server.close();


### PR DESCRIPTION
## Description

Support custom DNS lookup function. This is particularly useful to prevent user-controlled requests accessing internal services, by denying accessing requests where the resolved IP is not public.

### Alternatives

This could also be implemented by using a custom `preRequest` hook, but directly supporting the Http.request `lookup` parameter is the most straightforward way to pass options to a specific request.

I've implemented tests and documented the parameter both in API.md and in the index.d.ts file,  please tell me if there are other parts that I've missed! I didn't touch the package version out of caution.

Happy to discuss it.