### PR TITLE
Optimize header toLowerCasing

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -117,23 +117,26 @@ internals.Client = class {
         uri.method = method.toUpperCase();
         uri.headers = Object.assign({}, options.headers);
 
-        const hostHeader = internals.findHeader('host', uri.headers);
+        const usedHeaders = new Set();
+        for (const [key, value] of Object.entries(uri.headers)) {
+            if (value !== undefined) {
+                usedHeaders.add(key.toLowerCase());
+            }
+        }
 
-        if (!hostHeader) {
+        if (!usedHeaders.has('host')) {
             uri.headers.host = uri.host;
         }
 
-        const hasContentLength = internals.findHeader('content-length', uri.headers) !== undefined;
-
         if (options.payload && typeof options.payload === 'object' && !(options.payload instanceof Stream) && !Buffer.isBuffer(options.payload)) {
             options.payload = JSON.stringify(options.payload);
-            if (!internals.findHeader('content-type', uri.headers)) {
+            if (!usedHeaders.has('content-type')) {
                 uri.headers['content-type'] = 'application/json';
             }
         }
 
         if (options.gunzip &&
-            internals.findHeader('accept-encoding', uri.headers) === undefined) {
+            !usedHeaders.has('accept-encoding')) {
 
             uri.headers['accept-encoding'] = 'gzip';
         }
@@ -141,7 +144,7 @@ internals.Client = class {
         const payloadSupported = uri.method !== 'GET' && uri.method !== 'HEAD' && !internals.isNullOrUndefined(options.payload);
         if (payloadSupported &&
             (typeof options.payload === 'string' || Buffer.isBuffer(options.payload)) &&
-            !hasContentLength) {
+            !usedHeaders.has('content-length')) {
 
             uri.headers['content-length'] = Buffer.isBuffer(options.payload) ? options.payload.length : Buffer.byteLength(options.payload);
         }
@@ -393,7 +396,7 @@ internals.Client = class {
 
             // 'strict' or true
 
-            const contentType = res.headers && internals.findHeader('content-type', res.headers) || '';
+            const contentType = res.headers?.['content-type'] ?? '';
             const mime = contentType.split(';')[0].trim().toLowerCase();
 
             if (!internals.jsonRegex.test(mime)) {
@@ -459,7 +462,7 @@ internals.Client = class {
         if (options.gunzip) {
             const contentEncoding = options.gunzip === 'force' ?
                 'gzip' :
-                res.headers && internals.findHeader('content-encoding', res.headers) || '';
+                res.headers?.['content-encoding'] ?? '';
 
             if (/^(x-)?gzip(\s*,\s*identity)?$/.test(contentEncoding)) {
                 const gunzip = Zlib.createGunzip();
@@ -650,18 +653,6 @@ internals.tryParseBuffer = function (buffer, next) {
     }
 
     return next(null, payload);
-};
-
-
-internals.findHeader = function (headerName, headers) {
-
-    const normalizedName = headerName.toLowerCase();
-
-    for (const key of Object.keys(headers)) {
-        if (key.toLowerCase() === normalizedName) {
-            return headers[key];
-        }
-    }
 };
 
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -115,12 +115,15 @@ internals.Client = class {
         }
 
         uri.method = method.toUpperCase();
-        uri.headers = Object.assign({}, options.headers);
+        uri.headers = Object.create(null);
 
         const usedHeaders = new Set();
-        for (const [key, value] of Object.entries(uri.headers)) {
-            if (value !== undefined) {
-                usedHeaders.add(key.toLowerCase());
+        if (options.headers) {
+            for (const [key, value] of Object.entries(options.headers)) {
+                if (value !== undefined) {
+                    uri.headers[key] = value;
+                    usedHeaders.add(key.toLowerCase());
+                }
             }
         }
 

--- a/test/index.js
+++ b/test/index.js
@@ -1223,6 +1223,15 @@ describe('options.baseUrl', () => {
         flags.onCleanup = () => server.close();
     });
 
+    it('ignores host header when it is undefined', async (flags) => {
+
+        const server = await internals.server('ok');
+        flags.onCleanup = () => server.close();
+        const promise = Wreck.request('get', '/foo', { baseUrl: `http://localhost:${server.address().port}/`, headers: { host: undefined } });
+        await expect(promise).to.not.reject();
+        expect(promise.req.getHeader('host')).to.equal(`localhost:${server.address().port}`);
+    });
+
     it('uses baseUrl option with trailing slash and uri is prefixed with a slash', async (flags) => {
 
         const server = await internals.server('ok');


### PR DESCRIPTION
All requests currently include a number of calls to string `toLowerCase()` on header names. Especially if there are any user provided headers, where each provided header name is lowercased at 2 - 4 times.

This PR removes the need to lowercase when no headers are provided, and reduces it to a single time for each name when they are provided.

Additionally, this also fixes redundant lowercasing in `read()` where incoming headers would be lowercased, even though they already were by node.

This is a pure refactor, and should have no effect** other than requiring slightly less CPU/memory usage, while being easier to read.

** *The behaviour is actually changed for `''` values for `host` and `content-type`, where they are now considered set. Also for headers with "duplicate" entries, eg. `{ host: undefined, HOST: 'hello' }`, which will detect it as set, where the old logic would not.*