### PR TITLE
Use HTTPS for repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "@hapi/wreck",
     "description": "HTTP Client Utilities",
     "version": "18.1.2",
-    "repository": "git://github.com/hapijs/wreck",
+    "repository": "https://github.com/hapijs/wreck",
     "main": "lib/index",
     "types": "lib/index.d.ts",
     "keywords": [


### PR DESCRIPTION
## Summary
- update the package repository URL to use HTTPS instead of the legacy git protocol

## Validation
- git diff --check
- node -e 'JSON.parse(require("fs").readFileSync("package.json","utf8"))'